### PR TITLE
Bugfix/update logic for tasks to generate embeddings from

### DIFF
--- a/cli/test/conftest.py
+++ b/cli/test/conftest.py
@@ -7,15 +7,7 @@ import botocore.client
 import pytest
 from moto import mock_s3
 
-
-@pytest.fixture()
-def test_input_dir() -> Path:
-    return (Path(__file__).parent / "test_data" / "text2embeddings_input").resolve()
-
-
-@pytest.fixture()
-def test_input_dir_bad_data() -> Path:
-    return (Path(__file__).parent / "test_data" / "text2embeddings_input_bad").resolve()
+from src.base import TextBlock
 
 
 class S3Client:
@@ -1072,7 +1064,7 @@ def test_html_file_json() -> dict:
 
 
 @pytest.fixture
-def pipeline_s3_objects(
+def pipeline_s3_objects_main(
     test_file_key,
     test_html_file_json,
 ):
@@ -1090,7 +1082,7 @@ def pipeline_s3_objects(
 
 
 @pytest.fixture
-def pipeline_s3_client(s3_bucket_and_region, pipeline_s3_objects):
+def pipeline_s3_client_main(s3_bucket_and_region, pipeline_s3_objects_main):
     with mock_s3():
         s3_client = S3Client(s3_bucket_and_region["region"])
 
@@ -1101,11 +1093,24 @@ def pipeline_s3_client(s3_bucket_and_region, pipeline_s3_objects):
             },
         )
 
-        for key in pipeline_s3_objects:
+        for key in pipeline_s3_objects_main:
             s3_client.client.put_object(
                 Bucket=s3_bucket_and_region["bucket"],
                 Key=key,
-                Body=pipeline_s3_objects[key],
+                Body=pipeline_s3_objects_main[key],
             )
 
         yield s3_client
+
+
+def get_text_block(text_block_type: str) -> TextBlock:
+    """Returns a TextBlock object with the given type."""
+    return TextBlock(
+        text=["test_text"],
+        text_block_id="test_text_block_id",
+        language="test_language",
+        type=text_block_type,
+        type_confidence=1.0,
+        coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
+        page_number=0,
+    )

--- a/cli/test/conftest.py
+++ b/cli/test/conftest.py
@@ -1,6 +1,5 @@
 import json
 import os
-from pathlib import Path
 
 import boto3
 import botocore.client

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -61,7 +61,7 @@ def test_run_encoder_s3(
     pipeline_s3_objects_main,
     pipeline_s3_client_main,
     test_input_dir_s3,
-    test_output_dir_s3
+    test_output_dir_s3,
 ):
     """Test that the encoder runs with S3 input and output paths and outputs the correct files."""
 
@@ -75,7 +75,7 @@ def test_run_encoder_s3(
     # Check that the correct files were created
     for key in pipeline_s3_objects_main.keys():
         try:
-            s3client.head_object(Bucket=s3_bucket_and_region['bucket'], Key=key)
+            s3client.head_object(Bucket=s3_bucket_and_region["bucket"], Key=key)
             exists = True
         except Exception:
             exists = False

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -57,11 +57,11 @@ def test_run_encoder_local(
 
 
 def test_run_encoder_s3(
-        s3_bucket_and_region,
-        pipeline_s3_objects,
-        pipeline_s3_client,
-        test_input_dir_s3,
-        test_output_dir_s3
+    s3_bucket_and_region,
+    pipeline_s3_objects_main,
+    pipeline_s3_client_main,
+    test_input_dir_s3,
+    test_output_dir_s3
 ):
     """Test that the encoder runs with S3 input and output paths and outputs the correct files."""
 
@@ -73,14 +73,13 @@ def test_run_encoder_s3(
     s3client = boto3.client("s3")
 
     # Check that the correct files were created
-    for key in pipeline_s3_objects.keys():
+    for key in pipeline_s3_objects_main.keys():
         try:
             s3client.head_object(Bucket=s3_bucket_and_region['bucket'], Key=key)
             exists = True
         except Exception:
             exists = False
         assert exists
-
 
 
 def test_run_parser_skip_already_done(

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -46,7 +46,7 @@ def test_run_encoder_local(
             }
 
             for path in Path(output_dir).glob("*.json"):
-                assert IndexerInput.parse_raw(json.loads(path.read_text()))
+                assert IndexerInput.parse_obj(json.loads(path.read_text()))
 
             for path in Path(output_dir).glob("*.npy"):
                 assert np.load(str(path)).shape[1] == 768

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -46,7 +46,7 @@ def test_run_encoder_local(
             }
 
             for path in Path(output_dir).glob("*.json"):
-                assert IndexerInput.parse_raw(path.read_text())
+                assert IndexerInput.parse_raw(json.loads(path.read_text()))
 
             for path in Path(output_dir).glob("*.npy"):
                 assert np.load(str(path)).shape[1] == 768

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -174,9 +174,9 @@ def run_as_cli(
         task_output_path = os.path.join(output_dir, task.document_id + ".json")
 
         try:
-            write_json_to_s3(json.dumps(task.json()), task_output_path) if s3 else Path(
+            write_json_to_s3(task.json(), task_output_path) if s3 else Path(
                 task_output_path
-            ).write_text(json.dumps(task.json()))
+            ).write_text(task.json())
         except Exception as e:
             logger.info(
                 "Failed to write embeddings data to s3.",

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -2,6 +2,7 @@
 
 import logging
 import logging.config
+import json
 import os
 from pathlib import Path
 from typing import Optional
@@ -173,9 +174,9 @@ def run_as_cli(
         task_output_path = os.path.join(output_dir, task.document_id + ".json")
 
         try:
-            write_json_to_s3(task.json(), task_output_path) if s3 else Path(
+            write_json_to_s3(json.dumps(task.json()), task_output_path) if s3 else Path(
                 task_output_path
-            ).write_text(task.json())
+            ).write_text(json.dumps(task.json()))
         except Exception as e:
             logger.info(
                 "Failed to write embeddings data to s3.",

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -119,6 +119,8 @@ def run_as_cli(
 
     logger.info("Getting files to process.")
     files_to_process_ids = get_files_to_process(s3, input_dir, output_dir, redo, limit)
+    logger.info(f"Found {len(files_to_process_ids)} files to process.",
+                extra={"props": {"files_to_process_ids": files_to_process_ids}})
 
     logger.info("Constructing Text2EmbeddingsInput objects from parser output jsons.")
     tasks = get_Text2EmbeddingsInput_array(input_dir, s3, files_to_process_ids)
@@ -128,6 +130,8 @@ def run_as_cli(
         extra={"props": {"target_languages": config.TARGET_LANGUAGES}}
     )
     tasks = get_docs_of_supported_language(tasks)
+    logger.info(f"Found {len(tasks)} tasks with supported languages.",
+                extra={"props": {"tasks": [{'lang': task.languages, 'translated': task.translated, 'document_id': task.document_id} for task in tasks]}})
 
     logger.info(
         "Filtering unwanted text block types.",

--- a/src/config.py
+++ b/src/config.py
@@ -8,9 +8,7 @@ SBERT_MODEL: str = os.getenv("SBERT_MODEL", "msmarco-distilbert-dot-v5")
 INDEX_ENCODER_CACHE_FOLDER: str = os.getenv("INDEX_ENCODER_CACHE_FOLDER", "/models")
 ENCODING_BATCH_SIZE: int = int(os.getenv("ENCODING_BATCH_SIZE", "32"))
 # comma-separated 2-letter ISO codes
-TARGET_LANGUAGES: Set[str] = set(
-    os.getenv("TARGET_LANGUAGES", "en").lower().split(",")
-)
+TARGET_LANGUAGES: Set[str] = set(os.getenv("TARGET_LANGUAGES", "en").lower().split(","))
 ENCODER_SUPPORTED_LANGUAGES: Set[str] = {"en"}
 FILES_TO_PROCESS = os.getenv("FILES_TO_PROCESS")
 BLOCKS_TO_FILTER = os.getenv("BLOCKS_TO_FILTER", "Table,Figure").split(",")

--- a/src/languages.py
+++ b/src/languages.py
@@ -46,9 +46,10 @@ def get_docs_of_supported_language(tasks: List[Text2EmbeddingsInput]):
                    in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
                )
            )
-           # or (
-           #      not task.languages
-           #      and task.html_data is None
-           #      and task.pdf_data is None
-           # )
+           or (
+                not task.document_source_url
+                and not task.languages
+                and task.html_data is None
+                and task.pdf_data is None
+           )
     ]

--- a/src/languages.py
+++ b/src/languages.py
@@ -12,8 +12,8 @@ def validate_languages_decorator(func):
 
     def wrapper(*args, **kwargs):
         if (
-                unsupported_languages := config.TARGET_LANGUAGES
-                - config.ENCODER_SUPPORTED_LANGUAGES
+            unsupported_languages := config.TARGET_LANGUAGES
+            - config.ENCODER_SUPPORTED_LANGUAGES
         ):
             logger.warning(
                 f"The following languages have been requested for encoding but are not supported by the encoder: "
@@ -26,7 +26,9 @@ def validate_languages_decorator(func):
 
 
 @validate_languages_decorator
-def get_docs_of_supported_language(tasks: List[Text2EmbeddingsInput]):
+def get_docs_of_supported_language(
+    tasks: List[Text2EmbeddingsInput],
+) -> List[Text2EmbeddingsInput]:
     """Filter out documents that don't meet language requirements.
 
     Persist documents with either:
@@ -39,17 +41,17 @@ def get_docs_of_supported_language(tasks: List[Text2EmbeddingsInput]):
         task
         for task in tasks
         if (
-               task.languages
-               and (len(task.languages) == 1)
-               and (
-                   task.languages[0]
-                   in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
-               )
-           )
-           or (
-                not task.document_source_url
-                and not task.languages
-                and task.html_data is None
-                and task.pdf_data is None
-           )
+            task.languages
+            and (len(task.languages) == 1)
+            and (
+                task.languages[0]
+                in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
+            )
+        )
+        or (
+            not task.document_source_url
+            and not task.languages
+            and task.html_data is None
+            and task.pdf_data is None
+        )
     ]

--- a/src/languages.py
+++ b/src/languages.py
@@ -12,8 +12,8 @@ def validate_languages_decorator(func):
 
     def wrapper(*args, **kwargs):
         if (
-            unsupported_languages := config.TARGET_LANGUAGES
-            - config.ENCODER_SUPPORTED_LANGUAGES
+                unsupported_languages := config.TARGET_LANGUAGES
+                                         - config.ENCODER_SUPPORTED_LANGUAGES
         ):
             logger.warning(
                 f"The following languages have been requested for encoding but are not supported by the encoder: "
@@ -25,33 +25,42 @@ def validate_languages_decorator(func):
     return wrapper
 
 
+def task_has_one_lang_that_is_supported(task: Text2EmbeddingsInput) -> bool:
+    """Return true if the task has one language that is supported by the encoder."""
+    return (
+            task.languages
+            and (len(task.languages) == 1)
+            and (
+                    task.languages[0]
+                    in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
+            )
+    )
+
+
+def task_has_no_source_url_languages_or_data(task: Text2EmbeddingsInput) -> bool:
+    """Return true if the task has no source url, languages or html/pdf data."""
+    return (
+            not task.document_source_url
+            and not task.languages
+            and task.html_data is None
+            and task.pdf_data is None
+    )
+
+
 @validate_languages_decorator
 def get_docs_of_supported_language(
     tasks: List[Text2EmbeddingsInput],
 ) -> List[Text2EmbeddingsInput]:
     """Filter out documents that don't meet language requirements.
 
-    Persist documents with either:
-     - one language where the language is in the target languages
-     - no language and no content type.
-
-    This assumes that the document name and description are in English.
+    Empty documents that have a source url will have a translated output produced for them by the pdf parser
+    with a language that is supported by the encoder. Thus, we want to filter the root documents out (with no
+    language) as we don't want to encode the root non-translated document as well. This is why we have the
+    task_has_one_lang_that_is_supported function.
     """
     return [
         task
         for task in tasks
-        if (
-            task.languages
-            and (len(task.languages) == 1)
-            and (
-                task.languages[0]
-                in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
-            )
-        )
-        or (
-            not task.document_source_url
-            and not task.languages
-            and task.html_data is None
-            and task.pdf_data is None
-        )
+        if task_has_one_lang_that_is_supported(task)
+        or task_has_no_source_url_languages_or_data(task)
     ]

--- a/src/languages.py
+++ b/src/languages.py
@@ -13,7 +13,7 @@ def validate_languages_decorator(func):
     def wrapper(*args, **kwargs):
         if (
                 unsupported_languages := config.TARGET_LANGUAGES
-                                         - config.ENCODER_SUPPORTED_LANGUAGES
+                - config.ENCODER_SUPPORTED_LANGUAGES
         ):
             logger.warning(
                 f"The following languages have been requested for encoding but are not supported by the encoder: "

--- a/src/languages.py
+++ b/src/languages.py
@@ -1,9 +1,11 @@
 import logging
+from typing import List
 
 from src import config
 from src.base import Text2EmbeddingsInput
 
 logger = logging.getLogger(__name__)
+
 
 def validate_languages_decorator(func):
     """Validate that the languages requested for encoding are supported by the encoder."""
@@ -24,7 +26,7 @@ def validate_languages_decorator(func):
 
 
 @validate_languages_decorator
-def get_docs_of_supported_language(tasks: list[Text2EmbeddingsInput]):
+def get_docs_of_supported_language(tasks: List[Text2EmbeddingsInput]):
     """Filter out documents that don't meet language requirements.
 
     Persist documents with either:
@@ -44,9 +46,9 @@ def get_docs_of_supported_language(tasks: list[Text2EmbeddingsInput]):
                    in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
                )
            )
-           or (
-                not task.languages
-                and task.html_data is None
-                and task.pdf_data is None
-           )
+           # or (
+           #      not task.languages
+           #      and task.html_data is None
+           #      and task.pdf_data is None
+           # )
     ]

--- a/src/s3.py
+++ b/src/s3.py
@@ -106,12 +106,9 @@ def write_json_to_s3(json_data: dict, s3_path: str) -> None:
     """Writes JSON data to an S3 bucket."""
     bucket, key, s3client = validate_s3_pattern(s3_path)
 
-    # Convert JSON data to a string
-    json_string = json.dumps(json_data)
-
     # Upload the JSON string to S3
     try:
-        s3client.put_object(Body=json_string, Bucket=bucket, Key=key)
+        s3client.put_object(Body=json_data, Bucket=bucket, Key=key)
     except errors.NoSuchBucket:
         raise ValueError(f"Bucket {bucket} does not exist")
     except Exception as e:

--- a/src/s3.py
+++ b/src/s3.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Sequence
 
 import boto3
 from botocore.exceptions import ClientError
@@ -20,7 +20,7 @@ def validate_s3_pattern(s3_path: str):
 
 
 # TODO do we want to instantiate one client object and pass that through rather than instantiating each time?
-def check_file_exists_in_s3(s3_path: str):
+def check_file_exists_in_s3(s3_path: str) -> bool:
     """Checks whether a file exists in an S3 bucket."""
     bucket, key, s3client = validate_s3_pattern(s3_path)
     try:
@@ -36,7 +36,7 @@ def check_file_exists_in_s3(s3_path: str):
         raise e
 
 
-def get_s3_keys_with_prefix(s3_prefix: str) -> list[str]:
+def get_s3_keys_with_prefix(s3_prefix: str) -> Sequence[str]:
     """
     Get a list of keys in an S3 bucket with a given prefix. Returns an empty list if the prefix does not exist
     or is empty.
@@ -102,7 +102,7 @@ def s3_object_read_text(s3_path: str) -> str:
     return response["Body"].read().decode("utf-8")
 
 
-def write_json_to_s3(json_data: dict, s3_path: str) -> None:
+def write_json_to_s3(json_data: str, s3_path: str) -> None:
     """Writes JSON data to an S3 bucket."""
     bucket, key, s3client = validate_s3_pattern(s3_path)
 

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -66,7 +66,9 @@ def pipeline_s3_objects(
     Thus, we have a document that embeddings can be generated from in s3.
     """
     return {
-        f'{test_prefix}/test_id.json': bytes(json.dumps(test_file_json).encode("UTF-8")),
+        f"{test_prefix}/test_id.json": bytes(
+            json.dumps(test_file_json).encode("UTF-8")
+        ),
     }
 
 

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from moto import mock_s3
 
 from src.base import IndexerInput, DocumentMetadata, HTMLData
-from src.test.test_utils import get_text_block
+from cli.test.conftest import get_text_block
 
 
 class S3Client:

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,0 +1,118 @@
+import datetime
+from typing import List
+import pytest
+
+from src.base import IndexerInput, DocumentMetadata, HTMLData
+from src.test.test_utils import get_text_block
+
+
+@pytest.fixture
+def test_indexer_input_array() -> List[IndexerInput]:
+    """Test IndexerInput array with html containing various text block types."""
+    return [
+        IndexerInput(
+            document_id="test_id",
+            document_metadata=DocumentMetadata(
+                publication_ts=datetime.datetime.now(),
+                date="test_date",
+                geography="test_geography",
+                category="test_category",
+                source="test_source",
+                type="test_type",
+                sectors=["test_sector"],
+            ),
+            document_name="test_name",
+            document_description="test_description",
+            document_source_url="https://www.google.com/path.html",
+            document_cdn_object="test_cdn_object",
+            document_md5_sum="test_md5_sum",
+            languages=["test_language"],
+            translated=True,
+            document_slug="test_slug",
+            document_content_type="text/html",
+            html_data=HTMLData(
+                has_valid_text=True,
+                text_blocks=[
+                    get_text_block("Table"),
+                    get_text_block("Text"),
+                    get_text_block("Text"),
+                    get_text_block("Figure"),
+                    get_text_block("Text"),
+                    get_text_block("Random"),
+                    get_text_block("Google Text Block"),
+                ],
+            ),
+            pdf_data=None,
+        ),
+        IndexerInput(
+            document_id="test_id",
+            document_metadata=DocumentMetadata(
+                publication_ts=datetime.datetime.now(),
+                date="test_date",
+                geography="test_geography",
+                category="test_category",
+                source="test_source",
+                type="test_type",
+                sectors=["test_sector"],
+            ),
+            document_name="test_name",
+            document_description="test_description",
+            document_source_url="https://www.google.com/path.html",
+            document_cdn_object="test_cdn_object",
+            document_md5_sum="test_md5_sum",
+            languages=["test_language"],
+            translated=True,
+            document_slug="test_slug",
+            document_content_type="text/html",
+            html_data=HTMLData(
+                has_valid_text=False,
+                text_blocks=[
+                    get_text_block("Table"),
+                    get_text_block("Text"),
+                    get_text_block("Google Text Block"),
+                ],
+            ),
+            pdf_data=None,
+        ),
+    ]
+
+
+@pytest.fixture
+def test_indexer_input_no_lang() -> List[IndexerInput]:
+    """Test IndexerInput array with html containing various text block types."""
+    return [
+        IndexerInput(
+            document_id="test_id",
+            document_metadata=DocumentMetadata(
+                publication_ts=datetime.datetime.now(),
+                date="test_date",
+                geography="test_geography",
+                category="test_category",
+                source="test_source",
+                type="test_type",
+                sectors=["test_sector"],
+            ),
+            document_name="test_name",
+            document_description="test_description",
+            document_source_url="https://www.google.com/path.html",
+            document_cdn_object="test_cdn_object",
+            document_md5_sum="test_md5_sum",
+            languages=None,
+            translated=False,
+            document_slug="test_slug",
+            document_content_type="text/html",
+            html_data=HTMLData(
+                has_valid_text=True,
+                text_blocks=[
+                    get_text_block("Table"),
+                    get_text_block("Text"),
+                    get_text_block("Text"),
+                    get_text_block("Figure"),
+                    get_text_block("Text"),
+                    get_text_block("Random"),
+                    get_text_block("Google Text Block"),
+                ],
+            ),
+            pdf_data=None,
+        )
+    ]

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -116,3 +116,33 @@ def test_indexer_input_no_lang() -> List[IndexerInput]:
             pdf_data=None,
         )
     ]
+
+
+@pytest.fixture
+def test_indexer_input_no_source_url() -> List[IndexerInput]:
+    """Test IndexerInput array with html containing various text block types."""
+    return [
+        IndexerInput(
+            document_id="test_id",
+            document_metadata=DocumentMetadata(
+                publication_ts=datetime.datetime.now(),
+                date="test_date",
+                geography="test_geography",
+                category="test_category",
+                source="test_source",
+                type="test_type",
+                sectors=["test_sector"],
+            ),
+            document_name="test_name",
+            document_description="test_description",
+            document_source_url=None,
+            document_cdn_object=None,
+            document_md5_sum="test_md5_sum",
+            languages=None,
+            translated=False,
+            document_slug="test_slug",
+            document_content_type=None,
+            html_data=None,
+            pdf_data=None,
+        )
+    ]

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,9 +1,95 @@
 import datetime
 from typing import List
+import json
+import os
+import boto3
+import botocore.client
 import pytest
+from moto import mock_s3
 
 from src.base import IndexerInput, DocumentMetadata, HTMLData
 from src.test.test_utils import get_text_block
+
+
+class S3Client:
+    """Helper class to connect to S3 and perform actions on buckets and documents."""
+
+    def __init__(self, region):
+        self.client = boto3.client(
+            "s3",
+            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            config=botocore.client.Config(
+                signature_version="s3v4",
+                region_name=region,
+                connect_timeout=10,
+            ),
+        )
+
+
+@pytest.fixture
+def s3_bucket_and_region() -> dict:
+    return {
+        "bucket": "test-bucket",
+        "region": "eu-west-1",
+    }
+
+
+@pytest.fixture
+def test_file_json() -> dict:
+    return {
+        "document_id": "test_id",
+    }
+
+
+@pytest.fixture
+def test_prefix() -> str:
+    return "test_prefix"
+
+
+@pytest.fixture
+def test_file_key(s3_bucket_and_region, test_prefix) -> str:
+    return f"{s3_bucket_and_region['bucket']}/{test_prefix}/test_id.json"
+
+
+@pytest.fixture
+def pipeline_s3_objects(
+    test_prefix,
+    test_file_json,
+):
+    """
+    Return a dict of s3 objects to be used in the pipeline s3 client fixture.
+
+    This sets up a s3 bucket with the following objects:
+    - A fake document with a document_id of "test_id".
+
+    Thus, we have a document that embeddings can be generated from in s3.
+    """
+    return {
+        f'{test_prefix}/test_id.json': bytes(json.dumps(test_file_json).encode("UTF-8")),
+    }
+
+
+@pytest.fixture
+def pipeline_s3_client(s3_bucket_and_region, pipeline_s3_objects):
+    with mock_s3():
+        s3_client = S3Client(s3_bucket_and_region["region"])
+
+        s3_client.client.create_bucket(
+            Bucket=s3_bucket_and_region["bucket"],
+            CreateBucketConfiguration={
+                "LocationConstraint": s3_bucket_and_region["region"]
+            },
+        )
+
+        for key in pipeline_s3_objects:
+            s3_client.client.put_object(
+                Bucket=s3_bucket_and_region["bucket"],
+                Key=key,
+                Body=pipeline_s3_objects[key],
+            )
+
+        yield s3_client
 
 
 @pytest.fixture

--- a/src/test/test_languages.py
+++ b/src/test/test_languages.py
@@ -1,0 +1,27 @@
+from typing import List
+
+from src import config
+from src.base import Text2EmbeddingsInput
+from src.languages import get_docs_of_supported_language
+
+
+def test_get_docs_of_supported_language(
+    test_indexer_input_no_lang: List[Text2EmbeddingsInput],
+    test_indexer_input_array: List[Text2EmbeddingsInput],
+    test_indexer_input_no_source_url: List[Text2EmbeddingsInput],
+):
+    """Tests that the get_docs_of_supported_language function returns only docs of a supported language."""
+    docs_of_supported_languages = get_docs_of_supported_language(
+        test_indexer_input_no_lang + test_indexer_input_array + test_indexer_input_no_source_url
+    )
+    for doc in docs_of_supported_languages:
+        assert doc.languages in config.TARGET_LANGUAGES or (
+                doc.document_source_url is None
+                and not doc.languages
+                and doc.html_data is None
+                and doc.pdf_data is None
+        )
+
+
+# TODO test that the warning is logged if the document language is not supported by the encoder
+

--- a/src/test/test_languages.py
+++ b/src/test/test_languages.py
@@ -12,16 +12,17 @@ def test_get_docs_of_supported_language(
 ):
     """Tests that the get_docs_of_supported_language function returns only docs of a supported language."""
     docs_of_supported_languages = get_docs_of_supported_language(
-        test_indexer_input_no_lang + test_indexer_input_array + test_indexer_input_no_source_url
+        test_indexer_input_no_lang
+        + test_indexer_input_array
+        + test_indexer_input_no_source_url
     )
     for doc in docs_of_supported_languages:
         assert doc.languages in config.TARGET_LANGUAGES or (
-                doc.document_source_url is None
-                and not doc.languages
-                and doc.html_data is None
-                and doc.pdf_data is None
+            doc.document_source_url is None
+            and not doc.languages
+            and doc.html_data is None
+            and doc.pdf_data is None
         )
 
 
 # TODO test that the warning is logged if the document language is not supported by the encoder
-

--- a/src/test/test_languages.py
+++ b/src/test/test_languages.py
@@ -1,28 +1,30 @@
 from typing import List
 
-from src import config
 from src.base import Text2EmbeddingsInput
 from src.languages import get_docs_of_supported_language
 
+# TODO test that the warning is logged if the document language is not supported by the encoder
+
 
 def test_get_docs_of_supported_language(
-    test_indexer_input_no_lang: List[Text2EmbeddingsInput],
-    test_indexer_input_array: List[Text2EmbeddingsInput],
-    test_indexer_input_no_source_url: List[Text2EmbeddingsInput],
+    test_indexer_input_no_source_url_no_lang_no_data: List[Text2EmbeddingsInput],
+    test_indexer_input_source_url_no_lang_no_data: List[Text2EmbeddingsInput],
+    test_indexer_input_source_url_supported_lang_data: List[Text2EmbeddingsInput],
+    test_indexer_input_source_url_un_supported_lang_data: List[Text2EmbeddingsInput],
 ):
     """Tests that the get_docs_of_supported_language function returns only docs of a supported language."""
-    docs_of_supported_languages = get_docs_of_supported_language(
-        test_indexer_input_no_lang
-        + test_indexer_input_array
-        + test_indexer_input_no_source_url
-    )
-    for doc in docs_of_supported_languages:
-        assert doc.languages in config.TARGET_LANGUAGES or (
-            doc.document_source_url is None
-            and not doc.languages
-            and doc.html_data is None
-            and doc.pdf_data is None
-        )
+    assert get_docs_of_supported_language(
+        test_indexer_input_no_source_url_no_lang_no_data
+    ) == test_indexer_input_no_source_url_no_lang_no_data
 
+    assert get_docs_of_supported_language(
+        test_indexer_input_source_url_no_lang_no_data
+    ) == []
 
-# TODO test that the warning is logged if the document language is not supported by the encoder
+    assert get_docs_of_supported_language(
+        test_indexer_input_source_url_supported_lang_data
+    ) == test_indexer_input_source_url_supported_lang_data
+
+    assert get_docs_of_supported_language(
+        test_indexer_input_source_url_un_supported_lang_data
+    ) == []

--- a/src/test/test_ml.py
+++ b/src/test/test_ml.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from src import config
+from src.ml import SBERTEncoder
+
+
+def test_encoder():
+    """Assert that we can instantiate an encoder object and encode textual data using the class methods."""
+
+    encoder = SBERTEncoder(config.SBERT_MODEL)
+
+    assert encoder is not None
+
+    assert isinstance(encoder.encode("Hello world!"), np.ndarray)
+
+    assert isinstance(encoder.encode_batch(["Hello world!"]*100), np.ndarray)
+
+    assert encoder.dimension == 768

--- a/src/test/test_ml.py
+++ b/src/test/test_ml.py
@@ -13,6 +13,6 @@ def test_encoder():
 
     assert isinstance(encoder.encode("Hello world!"), np.ndarray)
 
-    assert isinstance(encoder.encode_batch(["Hello world!"]*100), np.ndarray)
+    assert isinstance(encoder.encode_batch(["Hello world!"] * 100), np.ndarray)
 
     assert encoder.dimension == 768

--- a/src/test/test_s3.py
+++ b/src/test/test_s3.py
@@ -1,0 +1,63 @@
+import json
+
+import numpy as np
+
+from src.s3 import validate_s3_pattern, check_file_exists_in_s3, get_s3_keys_with_prefix, s3_object_read_text, \
+    write_json_to_s3, save_ndarray_to_s3_as_npy
+
+
+def test_validate_s3_pattern(test_file_key):
+    """Test that validate_s3_pattern returns the correct bucket, client and key."""
+    bucket, key, s3client = validate_s3_pattern(f"s3://{test_file_key}")
+
+    assert bucket == "test-bucket"
+    assert key == "test_prefix/test_id.json"
+    assert s3client is not None
+
+    try:
+        validate_s3_pattern(f"random_string")
+    except Exception as e:
+        assert "Key does not represent an s3 path: random_string" in str(e)
+
+
+def test_check_file_exists_in_s3(pipeline_s3_client, test_file_key):
+    """Test whether we can check whether a file exists in s3."""
+
+    assert check_file_exists_in_s3(f"s3://{test_file_key}")
+    assert not check_file_exists_in_s3(f"s3://random_bucket/prefix/file.json")
+
+
+def test_get_s3_keys_with_prefix(pipeline_s3_client, s3_bucket_and_region, test_prefix, test_file_key):
+    """Test that we can get a list of keys with a given prefix."""
+    assert get_s3_keys_with_prefix(f"s3://{s3_bucket_and_region['bucket']}/{test_prefix}/") == [f'{test_prefix}/test_id.json']
+
+    try:
+        get_s3_keys_with_prefix(f"random_string")
+    except Exception as e:
+        assert "Prefix does not represent an s3 path: random_string" in str(e)
+
+
+def test_s3_object_read_text(pipeline_s3_client, test_file_key, test_file_json):
+    """Test that we can read text from an s3 object."""
+    assert json.loads(s3_object_read_text(f"s3://{test_file_key}")) == test_file_json
+
+
+def test_write_json_to_s3(pipeline_s3_client, s3_bucket_and_region, test_file_json):
+    """Test that we can write json to an s3 object."""
+    write_json_to_s3(bytes(json.dumps(test_file_json).encode("UTF-8")), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json")
+    assert json.loads(
+        s3_object_read_text(f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json")
+    ) == test_file_json
+
+
+def test_save_ndarray_to_s3_as_npy(pipeline_s3_client, s3_bucket_and_region):
+    """Test that we can save an ndarray to s3."""
+    save_ndarray_to_s3_as_npy(np.array([1, 2, 3]), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy")
+
+    assert check_file_exists_in_s3(f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy")
+
+    try:
+        save_ndarray_to_s3_as_npy(np.array([1, 2, 3]), "s3://random_bucket/prefix/test.npy")
+    except Exception as e:
+        assert f"Bucket random_bucket does not exist" in str(e)
+

--- a/src/test/test_s3.py
+++ b/src/test/test_s3.py
@@ -55,7 +55,7 @@ def test_s3_object_read_text(pipeline_s3_client, test_file_key, test_file_json):
 def test_write_json_to_s3(pipeline_s3_client, s3_bucket_and_region, test_file_json):
     """Test that we can write json to an s3 object."""
     write_json_to_s3(
-        str(test_file_json), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json"
+        json.dumps(test_file_json), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json"
     )
     assert (
         json.loads(

--- a/src/test/test_s3.py
+++ b/src/test/test_s3.py
@@ -2,8 +2,14 @@ import json
 
 import numpy as np
 
-from src.s3 import validate_s3_pattern, check_file_exists_in_s3, get_s3_keys_with_prefix, s3_object_read_text, \
-    write_json_to_s3, save_ndarray_to_s3_as_npy
+from src.s3 import (
+    validate_s3_pattern,
+    check_file_exists_in_s3,
+    get_s3_keys_with_prefix,
+    s3_object_read_text,
+    write_json_to_s3,
+    save_ndarray_to_s3_as_npy,
+)
 
 
 def test_validate_s3_pattern(test_file_key):
@@ -27,9 +33,13 @@ def test_check_file_exists_in_s3(pipeline_s3_client, test_file_key):
     assert not check_file_exists_in_s3(f"s3://random_bucket/prefix/file.json")
 
 
-def test_get_s3_keys_with_prefix(pipeline_s3_client, s3_bucket_and_region, test_prefix, test_file_key):
+def test_get_s3_keys_with_prefix(
+    pipeline_s3_client, s3_bucket_and_region, test_prefix, test_file_key
+):
     """Test that we can get a list of keys with a given prefix."""
-    assert get_s3_keys_with_prefix(f"s3://{s3_bucket_and_region['bucket']}/{test_prefix}/") == [f'{test_prefix}/test_id.json']
+    assert get_s3_keys_with_prefix(
+        f"s3://{s3_bucket_and_region['bucket']}/{test_prefix}/"
+    ) == [f"{test_prefix}/test_id.json"]
 
     try:
         get_s3_keys_with_prefix(f"random_string")
@@ -44,20 +54,32 @@ def test_s3_object_read_text(pipeline_s3_client, test_file_key, test_file_json):
 
 def test_write_json_to_s3(pipeline_s3_client, s3_bucket_and_region, test_file_json):
     """Test that we can write json to an s3 object."""
-    write_json_to_s3(bytes(json.dumps(test_file_json).encode("UTF-8")), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json")
-    assert json.loads(
-        s3_object_read_text(f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json")
-    ) == test_file_json
+    write_json_to_s3(
+        str(test_file_json), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json"
+    )
+    assert (
+        json.loads(
+            s3_object_read_text(
+                f"s3://{s3_bucket_and_region['bucket']}/prefix/test.json"
+            )
+        )
+        == test_file_json
+    )
 
 
 def test_save_ndarray_to_s3_as_npy(pipeline_s3_client, s3_bucket_and_region):
     """Test that we can save an ndarray to s3."""
-    save_ndarray_to_s3_as_npy(np.array([1, 2, 3]), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy")
+    save_ndarray_to_s3_as_npy(
+        np.array([1, 2, 3]), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy"
+    )
 
-    assert check_file_exists_in_s3(f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy")
+    assert check_file_exists_in_s3(
+        f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy"
+    )
 
     try:
-        save_ndarray_to_s3_as_npy(np.array([1, 2, 3]), "s3://random_bucket/prefix/test.npy")
+        save_ndarray_to_s3_as_npy(
+            np.array([1, 2, 3]), "s3://random_bucket/prefix/test.npy"
+        )
     except Exception as e:
         assert f"Bucket random_bucket does not exist" in str(e)
-

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -3,8 +3,13 @@ import numpy as np
 from src import config
 from src.base import IndexerInput, TextBlock, Text2EmbeddingsInput
 from src.ml import SBERTEncoder
-from src.utils import filter_on_block_type, replace_text_blocks, filter_blocks, get_ids_with_suffix, \
-    encode_indexer_input
+from src.utils import (
+    filter_on_block_type,
+    replace_text_blocks,
+    filter_blocks,
+    get_ids_with_suffix,
+    encode_indexer_input,
+)
 from cli.test.conftest import get_text_block, test_pdf_file_json
 
 
@@ -42,12 +47,12 @@ def test_has_valid_text_override(test_indexer_input_array):
 
     assert test_indexer_input_array[1].get_text_blocks() == []
     assert (
-            test_indexer_input_array[1].get_text_blocks(including_invalid_html=True)
-            is not []
+        test_indexer_input_array[1].get_text_blocks(including_invalid_html=True)
+        is not []
     )
     assert (
-            len(test_indexer_input_array[1].get_text_blocks(including_invalid_html=True))
-            == 3
+        len(test_indexer_input_array[1].get_text_blocks(including_invalid_html=True))
+        == 3
     )
 
 
@@ -57,15 +62,17 @@ def test_replace_text_blocks(test_pdf_file_json):
 
     updated_indexer_input = replace_text_blocks(
         block=indexer_input,
-        new_text_blocks=[TextBlock(
-            text=["test_text_2"],
-            text_block_id="test_text_block_id_2",
-            language="test_language_2",
-            type="Text",
-            type_confidence=1.0,
-            coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
-            page_number=0,
-        )],
+        new_text_blocks=[
+            TextBlock(
+                text=["test_text_2"],
+                text_block_id="test_text_block_id_2",
+                language="test_language_2",
+                type="Text",
+                type_confidence=1.0,
+                coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
+                page_number=0,
+            )
+        ],
     )
 
     assert len(updated_indexer_input.pdf_data.text_blocks) == 1
@@ -77,8 +84,7 @@ def test_filter_blocks(test_pdf_file_json):
     indexer_input = IndexerInput.parse_obj(test_pdf_file_json)
 
     filtered_text_blocks = filter_blocks(
-        indexer_input=indexer_input,
-        remove_block_types=["Text"]
+        indexer_input=indexer_input, remove_block_types=["Text"]
     )
 
     for block in filtered_text_blocks:
@@ -94,9 +100,9 @@ def test_get_ids_with_suffix():
             "s3://bucket/prefix/test_id_1.json",
             "s3://bucket/prefix/test_id_2.xlsx",
             "s3://bucket/prefix/test_id_3.npy",
-            "s3://bucket/prefix/test_id_4.json"
+            "s3://bucket/prefix/test_id_4.json",
         ],
-        suffix=".json"
+        suffix=".json",
     )
 
     assert len(filtered_ids) == 2
@@ -109,14 +115,10 @@ def test_encode_indexer_input(test_pdf_file_json):
 
     test_pdf_file_json.update({"document_metadata": {"metadata_key": "metadata_value"}})
 
-    input_obj = Text2EmbeddingsInput.parse_obj(
-        test_pdf_file_json
-    )
+    input_obj = Text2EmbeddingsInput.parse_obj(test_pdf_file_json)
 
     description_embeddings, text_embeddings = encode_indexer_input(
-        encoder=encoder_obj,
-        input_obj=input_obj,
-        batch_size=32
+        encoder=encoder_obj, input_obj=input_obj, batch_size=32
     )
 
     assert isinstance(description_embeddings, np.ndarray)

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -1,8 +1,4 @@
-from typing import List
-
-from src import config
-from src.base import TextBlock, IndexerInput, Text2EmbeddingsInput
-from src.languages import get_docs_of_supported_language
+from src.base import TextBlock
 from src.utils import filter_on_block_type
 
 
@@ -63,12 +59,4 @@ def test_has_valid_text_override(test_indexer_input_array):
 
 
 # TODO add tests for the other methods in utils.py
-def test_get_docs_of_supported_language(
-    test_indexer_input_no_lang: List[Text2EmbeddingsInput],
-    test_indexer_input_array: List[Text2EmbeddingsInput]
-):
-    """Tests that the get_docs_of_supported_language function returns only docs of a supported language."""
-    docs_of_supported_languages = get_docs_of_supported_language(test_indexer_input_no_lang + test_indexer_input_array)
-    for doc in docs_of_supported_languages:
-        assert doc.languges in config.TARGET_LANGUAGES
 

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -1,18 +1,11 @@
-from src.base import TextBlock
-from src.utils import filter_on_block_type
+import numpy as np
 
-
-def get_text_block(text_block_type: str) -> TextBlock:
-    """Returns a TextBlock object with the given type."""
-    return TextBlock(
-        text=["test_text"],
-        text_block_id="test_text_block_id",
-        language="test_language",
-        type=text_block_type,
-        type_confidence=1.0,
-        coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
-        page_number=0,
-    )
+from src import config
+from src.base import IndexerInput, TextBlock, Text2EmbeddingsInput
+from src.ml import SBERTEncoder
+from src.utils import filter_on_block_type, replace_text_blocks, filter_blocks, get_ids_with_suffix, \
+    encode_indexer_input
+from cli.test.conftest import get_text_block, test_pdf_file_json
 
 
 def test_filter_on_block_type(test_indexer_input_array):
@@ -53,10 +46,85 @@ def test_has_valid_text_override(test_indexer_input_array):
             is not []
     )
     assert (
-        len(test_indexer_input_array[1].get_text_blocks(including_invalid_html=True))
-        == 3
+            len(test_indexer_input_array[1].get_text_blocks(including_invalid_html=True))
+            == 3
     )
 
 
-# TODO add tests for the other methods in utils.py
+def test_replace_text_blocks(test_pdf_file_json):
+    """Tests that the replace_text_blocks function replaces the correct text blocks."""
+    indexer_input = IndexerInput.parse_obj(test_pdf_file_json)
 
+    updated_indexer_input = replace_text_blocks(
+        block=indexer_input,
+        new_text_blocks=[TextBlock(
+            text=["test_text_2"],
+            text_block_id="test_text_block_id_2",
+            language="test_language_2",
+            type="Text",
+            type_confidence=1.0,
+            coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
+            page_number=0,
+        )],
+    )
+
+    assert len(updated_indexer_input.pdf_data.text_blocks) == 1
+    assert updated_indexer_input.pdf_data.text_blocks[0].text == ["test_text_2"]
+
+
+def test_filter_blocks(test_pdf_file_json):
+    """Tests that the filter_blocks function removes the correct text blocks."""
+    indexer_input = IndexerInput.parse_obj(test_pdf_file_json)
+
+    filtered_text_blocks = filter_blocks(
+        indexer_input=indexer_input,
+        remove_block_types=["Text"]
+    )
+
+    for block in filtered_text_blocks:
+        assert block.type != "Text"
+
+    assert len(filtered_text_blocks) > 0
+
+
+def test_get_ids_with_suffix():
+    """Tests that the get_ids_with_suffix function returns the correct ids after filtering."""
+    filtered_ids = get_ids_with_suffix(
+        files=[
+            "s3://bucket/prefix/test_id_1.json",
+            "s3://bucket/prefix/test_id_2.xlsx",
+            "s3://bucket/prefix/test_id_3.npy",
+            "s3://bucket/prefix/test_id_4.json"
+        ],
+        suffix=".json"
+    )
+
+    assert len(filtered_ids) == 2
+    assert set(filtered_ids) == {"test_id_1", "test_id_4"}
+
+
+def test_encode_indexer_input(test_pdf_file_json):
+    """Tests that the encode_indexer_input function returns the correct embeddings."""
+    encoder_obj = SBERTEncoder(config.SBERT_MODEL)
+
+    test_pdf_file_json.update({"document_metadata": {"metadata_key": "metadata_value"}})
+
+    input_obj = Text2EmbeddingsInput.parse_obj(
+        test_pdf_file_json
+    )
+
+    description_embeddings, text_embeddings = encode_indexer_input(
+        encoder=encoder_obj,
+        input_obj=input_obj,
+        batch_size=32
+    )
+
+    assert isinstance(description_embeddings, np.ndarray)
+    assert isinstance(text_embeddings, np.ndarray)
+
+
+# TODO get_files_to_process
+#   TODO local files, s3 files, environment variable files
+
+# TODO get_Text2EmbeddingsInput_array
+#   TODO needs s3 files, local files, of the form json IndexerInput objects

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -1,8 +1,8 @@
-import datetime
+from typing import List
 
-import pytest
-
-from src.base import IndexerInput, DocumentMetadata, HTMLData, TextBlock
+from src import config
+from src.base import TextBlock, IndexerInput, Text2EmbeddingsInput
+from src.languages import get_docs_of_supported_language
 from src.utils import filter_on_block_type
 
 
@@ -17,77 +17,6 @@ def get_text_block(text_block_type: str) -> TextBlock:
         coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
         page_number=0,
     )
-
-
-@pytest.fixture
-def test_indexer_input_array() -> list[IndexerInput]:
-    """Test IndexerInput array with html containing various text block types."""
-    return [
-        IndexerInput(
-            document_id="test_id",
-            document_metadata=DocumentMetadata(
-                publication_ts=datetime.datetime.now(),
-                date="test_date",
-                geography="test_geography",
-                category="test_category",
-                source="test_source",
-                type="test_type",
-                sectors=["test_sector"],
-            ),
-            document_name="test_name",
-            document_description="test_description",
-            document_source_url="https://www.google.com/path.html",
-            document_cdn_object="test_cdn_object",
-            document_md5_sum="test_md5_sum",
-            languages=["test_language"],
-            translated=True,
-            document_slug="test_slug",
-            document_content_type="text/html",
-            html_data=HTMLData(
-                has_valid_text=True,
-                text_blocks=[
-                    get_text_block("Table"),
-                    get_text_block("Text"),
-                    get_text_block("Text"),
-                    get_text_block("Figure"),
-                    get_text_block("Text"),
-                    get_text_block("Random"),
-                    get_text_block("Google Text Block"),
-                ],
-            ),
-            pdf_data=None,
-        ),
-        IndexerInput(
-            document_id="test_id",
-            document_metadata=DocumentMetadata(
-                publication_ts=datetime.datetime.now(),
-                date="test_date",
-                geography="test_geography",
-                category="test_category",
-                source="test_source",
-                type="test_type",
-                sectors=["test_sector"],
-            ),
-            document_name="test_name",
-            document_description="test_description",
-            document_source_url="https://www.google.com/path.html",
-            document_cdn_object="test_cdn_object",
-            document_md5_sum="test_md5_sum",
-            languages=["test_language"],
-            translated=True,
-            document_slug="test_slug",
-            document_content_type="text/html",
-            html_data=HTMLData(
-                has_valid_text=False,
-                text_blocks=[
-                    get_text_block("Table"),
-                    get_text_block("Text"),
-                    get_text_block("Google Text Block"),
-                ],
-            ),
-            pdf_data=None,
-        ),
-    ]
 
 
 def test_filter_on_block_type(test_indexer_input_array):
@@ -124,8 +53,8 @@ def test_has_valid_text_override(test_indexer_input_array):
 
     assert test_indexer_input_array[1].get_text_blocks() == []
     assert (
-        test_indexer_input_array[1].get_text_blocks(including_invalid_html=True)
-        is not []
+            test_indexer_input_array[1].get_text_blocks(including_invalid_html=True)
+            is not []
     )
     assert (
         len(test_indexer_input_array[1].get_text_blocks(including_invalid_html=True))
@@ -134,3 +63,12 @@ def test_has_valid_text_override(test_indexer_input_array):
 
 
 # TODO add tests for the other methods in utils.py
+def test_get_docs_of_supported_language(
+    test_indexer_input_no_lang: List[Text2EmbeddingsInput],
+    test_indexer_input_array: List[Text2EmbeddingsInput]
+):
+    """Tests that the get_docs_of_supported_language function returns only docs of a supported language."""
+    docs_of_supported_languages = get_docs_of_supported_language(test_indexer_input_no_lang + test_indexer_input_array)
+    for doc in docs_of_supported_languages:
+        assert doc.languges in config.TARGET_LANGUAGES
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Tuple, Union, List, Set
+from typing import Optional, Tuple, Union, List, Set, Sequence
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from src.s3 import get_s3_keys_with_prefix, s3_object_read_text
 logger = logging.getLogger(__name__)
 
 
-def replace_text_blocks(block: IndexerInput, new_text_blocks: list[TextBlock]):
+def replace_text_blocks(block: IndexerInput, new_text_blocks: Sequence[TextBlock]):
     """Updates the text blocks in the IndexerInput object."""
     if block.pdf_data is not None:
         block.pdf_data.text_blocks = new_text_blocks
@@ -25,8 +25,8 @@ def replace_text_blocks(block: IndexerInput, new_text_blocks: list[TextBlock]):
 
 
 def filter_blocks(
-    indexer_input: IndexerInput, remove_block_types: list[str]
-) -> list[TextBlock]:
+    indexer_input: IndexerInput, remove_block_types: Sequence[str]
+) -> Sequence[TextBlock]:
     """Given an Indexer Input filter the contained TextBlocks and return this as a list of TextBlocks."""
     filtered_blocks = []
     for block in indexer_input.get_text_blocks(including_invalid_html=True):
@@ -47,10 +47,10 @@ def filter_blocks(
 
 
 def filter_on_block_type(
-    inputs: list[IndexerInput], remove_block_types: list[str]
-) -> list[IndexerInput]:
-    """Filter a sequence of IndexerInputs to remove the textblocks that are of the types declared in the remove block
-    types array."""
+    inputs: Sequence[IndexerInput], remove_block_types: List[str]
+) -> Sequence[IndexerInput]:
+    """Filter a sequence of IndexerInputs to remove the textblocks that are of the types declared in the remove
+    block types array."""
     for _filter in remove_block_types:
         try:
             BlockTypes(_filter)
@@ -71,7 +71,7 @@ def filter_on_block_type(
     ]
 
 
-def get_ids_with_suffix(files: List[str], suffix: str) -> Set[str]:
+def get_ids_with_suffix(files: Sequence[str], suffix: str) -> Set[str]:
     """Get a set of the ids of the files with the given suffix."""
     files = [file for file in files if file.endswith(suffix)]
     return set([os.path.splitext(os.path.basename(file))[0] for file in files])
@@ -92,7 +92,9 @@ def encode_indexer_input(
     :param device: device to use for encoding
     """
 
-    description_embedding = encoder.encode(input_obj.document_description, device=device)
+    description_embedding = encoder.encode(
+        input_obj.document_description, device=device
+    )
 
     text_blocks = input_obj.get_text_blocks()
 
@@ -108,7 +110,9 @@ def encode_indexer_input(
     return description_embedding, text_embeddings
 
 
-def get_files_to_process(s3: bool, input_dir: str, output_dir: str, redo: bool, limit: Union[None, int]) -> list:
+def get_files_to_process(
+    s3: bool, input_dir: str, output_dir: str, redo: bool, limit: Union[None, int]
+) -> Sequence[str]:
     """Get the list of files to process, either from the config or from the input directory."""
     if s3:
         document_paths_previously_parsed = get_s3_keys_with_prefix(output_dir)
@@ -154,7 +158,7 @@ def get_files_to_process(s3: bool, input_dir: str, output_dir: str, redo: bool, 
 
 
 def get_Text2EmbeddingsInput_array(
-        input_dir: str, s3: bool, files_to_process_ids
+    input_dir: str, s3: bool, files_to_process_ids: List[str]
 ) -> List[Text2EmbeddingsInput]:
     """Construct Text2EmbeddingsInput objects from parser output jsons.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -158,7 +158,7 @@ def get_files_to_process(
 
 
 def get_Text2EmbeddingsInput_array(
-    input_dir: str, s3: bool, files_to_process_ids: List[str]
+    input_dir: str, s3: bool, files_to_process_ids: Sequence[str]
 ) -> List[Text2EmbeddingsInput]:
     """Construct Text2EmbeddingsInput objects from parser output jsons.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, List, Set
 
 import numpy as np
 
@@ -12,6 +12,7 @@ from src.ml import SentenceEncoder
 from src.s3 import get_s3_keys_with_prefix, s3_object_read_text
 
 logger = logging.getLogger(__name__)
+
 
 def replace_text_blocks(block: IndexerInput, new_text_blocks: list[TextBlock]):
     """Updates the text blocks in the IndexerInput object."""
@@ -70,7 +71,7 @@ def filter_on_block_type(
     ]
 
 
-def get_ids_with_suffix(files: list[str], suffix: str) -> set[str]:
+def get_ids_with_suffix(files: List[str], suffix: str) -> Set[str]:
     """Get a set of the ids of the files with the given suffix."""
     files = [file for file in files if file.endswith(suffix)]
     return set([os.path.splitext(os.path.basename(file))[0] for file in files])
@@ -114,6 +115,7 @@ def get_files_to_process(s3: bool, input_dir: str, output_dir: str, redo: bool, 
     else:
         document_paths_previously_parsed = set(os.listdir(output_dir))
 
+    # TODO will this work for translated
     document_ids_previously_parsed = get_ids_with_suffix(
         document_paths_previously_parsed, ".npy"
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -115,7 +115,6 @@ def get_files_to_process(s3: bool, input_dir: str, output_dir: str, redo: bool, 
     else:
         document_paths_previously_parsed = set(os.listdir(output_dir))
 
-    # TODO will this work for translated
     document_ids_previously_parsed = get_ids_with_suffix(
         document_paths_previously_parsed, ".npy"
     )

--- a/src/utils.py
+++ b/src/utils.py
@@ -155,7 +155,7 @@ def get_files_to_process(s3: bool, input_dir: str, output_dir: str, redo: bool, 
 
 def get_Text2EmbeddingsInput_array(
         input_dir: str, s3: bool, files_to_process_ids
-) -> list[Text2EmbeddingsInput]:
+) -> List[Text2EmbeddingsInput]:
     """Construct Text2EmbeddingsInput objects from parser output jsons.
 
     These objects will be used to generate embeddings and are either read in from S3 or from the local file


### PR DESCRIPTION
Updating the logic for tasks that embeddings are generated for. This logic can be seen in the languages module.

The logic change is to create embeddings for empty files with no source url as opposed to empty files with or without a source url. 

Explanation: 
Empty documents that have a source url will have a translated output produced for them by the pdf parser
with a language that is supported by the encoder. 

Thus, we want to filter the root documents out (with no language) as we don't want to encode the root non-translated document as well. 

```
create embeddings if: 
        if task_has_one_lang_that_is_supported(task)
        or task_has_no_source_url_languages_or_data(task)
```
        



Adding unit tests for the application as well as refactoring.