### PR TITLE
Bugfix to produce the correct npy format for s3 runs 

### DIFF
--- a/cli/test/conftest.py
+++ b/cli/test/conftest.py
@@ -44,16 +44,6 @@ def output_prefix() -> str:
 
 
 @pytest.fixture
-def test_file_name() -> str:
-    return "CCLWTEST.executive.1.1.json"
-
-
-@pytest.fixture
-def test_file_key(s3_bucket_and_region, input_prefix, test_file_name) -> str:
-    return "embeddings_input_test/test.txt"
-
-
-@pytest.fixture
 def test_input_dir_s3(s3_bucket_and_region, input_prefix) -> str:
     return f"s3://{s3_bucket_and_region['bucket']}/{input_prefix}/"
 
@@ -1064,8 +1054,10 @@ def test_html_file_json() -> dict:
 
 @pytest.fixture
 def pipeline_s3_objects_main(
-    test_file_key,
+    input_prefix,
     test_html_file_json,
+    test_pdf_file_json,
+    test_no_content_type_file_json
 ):
     """
     Return a dict of s3 objects to be used in the pipeline s3 client fixture.
@@ -1076,7 +1068,9 @@ def pipeline_s3_objects_main(
     Thus, we have a document that embeddings can be generated from in s3.
     """
     return {
-        test_file_key: bytes(json.dumps(test_html_file_json).encode("UTF-8")),
+        f'{input_prefix}/CCLWTEST.executive.1000.1000.json': bytes(json.dumps(test_html_file_json).encode("UTF-8")),
+        f'{input_prefix}/CCLWTEST.executive.1001.1001.json': bytes(json.dumps(test_pdf_file_json).encode("UTF-8")),
+        f'{input_prefix}/CCLWTEST.executive.1002.1002.json': bytes(json.dumps(test_no_content_type_file_json).encode("UTF-8")),
     }
 
 

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 import tempfile
@@ -115,8 +116,9 @@ def test_run_encoder_s3(
 
     for file in s3_files_npy:
         file_obj = pipeline_s3_client_main.client.get_object(Bucket=s3_bucket_and_region['bucket'], Key=file)
-        file_text = file_obj["Body"].read()
-        assert np.load(file_text).shape == (1, 768)
+        file_text = file_obj["Body"]
+        file_bytes = io.BytesIO(file_text.read())
+        assert np.load(file_bytes).shape[1] == 768
 
 
 def test_run_parser_skip_already_done(

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -74,12 +74,12 @@ def test_run_encoder_s3(
 
     # Check that the correct files were created
     for key in pipeline_s3_objects_main.keys():
-        try:
-            s3client.head_object(Bucket=s3_bucket_and_region["bucket"], Key=key)
-            exists = True
-        except Exception:
-            exists = False
-        assert exists
+        assert s3client.head_object(Bucket=s3_bucket_and_region["bucket"], Key=key) is not None
+
+    # Check that the files have the correct format
+    for key in pipeline_s3_objects_main.keys():
+        obj = s3client.get_object(Bucket=s3_bucket_and_region["bucket"], Key=key)
+        assert np.load(obj).shape == (1, 768)
 
 
 def test_run_parser_skip_already_done(

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -80,6 +80,9 @@ def test_run_encoder_s3(
     # TODO get a set of output dir files npy
     s3_files_npy = [f for f in s3_files if f.endswith(".npy")]
 
+    assert len(s3_files_json) == 3
+    assert len(s3_files_npy) == 3
+
     assert set(s3_files_json) == {
         test_output_dir_s3 + "test_html.json",
         test_output_dir_s3 + "test_pdf.json",

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -75,7 +75,6 @@ def test_run_encoder_s3(
     test_input_dir_s3,
     test_output_dir_s3,
     output_prefix,
-    input_prefix
 ):
     """Test that the encoder runs with S3 input and output paths and outputs the correct files."""
 
@@ -84,8 +83,10 @@ def test_run_encoder_s3(
 
     assert result.exit_code == 0
 
-    list_response = pipeline_s3_client_main.client.list_objects_v2(Bucket=s3_bucket_and_region['bucket'],
-                                                                   Prefix=output_prefix)
+    list_response = pipeline_s3_client_main.client.list_objects_v2(
+        Bucket=s3_bucket_and_region['bucket'],
+        Prefix=output_prefix
+    )
 
     assert list_response['KeyCount'] == len(pipeline_s3_objects_main) * 2
 
@@ -157,8 +158,8 @@ def test_run_parser_skip_already_done(
                 all_messages = all_messages + i
 
             assert (
-                    "Found 3 documents that have already been encoded. Skipping."
-                    in all_messages
+                "Found 3 documents that have already been encoded. Skipping."
+                in all_messages
             )
 
             assert "No more documents to encode. Exiting." in all_messages

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -9,6 +9,7 @@ import boto3
 
 from cli.text2embeddings import run_as_cli
 from src.base import IndexerInput
+from src.s3 import get_s3_keys_with_prefix
 
 
 def test_run_encoder_local(
@@ -73,8 +74,8 @@ def test_run_encoder_s3(
 
     s3client = boto3.client("s3")
 
-    s3_files = s3client.list_objects_v2(Bucket=s3_bucket_and_region['bucket'], Prefix=output_prefix)
-    s3_files = [o["Key"] for o in s3_files.get("Contents", []) if o["Key"] != output_prefix]
+    s3_files = get_s3_keys_with_prefix(s3_prefix=f's3://{s3_bucket_and_region["bucket"]}/{output_prefix}')
+
     # TODO get a set of output dir files json
     s3_files_json = [f for f in s3_files if f.endswith(".json")]
     # TODO get a set of output dir files npy

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -5,17 +5,15 @@ from pathlib import Path
 
 import numpy as np
 from click.testing import CliRunner
-import boto3
 
 from cli.text2embeddings import run_as_cli
 from src.base import IndexerInput
-from src.s3 import get_s3_keys_with_prefix
 
 
 def test_run_encoder_local(
-        test_html_file_json,
-        test_pdf_file_json,
-        test_no_content_type_file_json,
+    test_html_file_json,
+    test_pdf_file_json,
+    test_no_content_type_file_json,
 ):
     """Test that the encoder runs with local input and output paths and outputs the correct files."""
 
@@ -57,10 +55,10 @@ def test_run_encoder_local(
 
 
 def test_s3_client(
-        s3_bucket_and_region,
-        pipeline_s3_objects_main,
-        pipeline_s3_client_main,
-        input_prefix,
+    s3_bucket_and_region,
+    pipeline_s3_objects_main,
+    pipeline_s3_client_main,
+    input_prefix,
 ):
     """Prior to running the embeddings generation tests assert that the mock s3 bucket is in the required state."""
     list_response = pipeline_s3_client_main.client.list_objects_v2(
@@ -70,13 +68,13 @@ def test_s3_client(
 
 
 def test_run_encoder_s3(
-        s3_bucket_and_region,
-        pipeline_s3_objects_main,
-        pipeline_s3_client_main,
-        test_input_dir_s3,
-        test_output_dir_s3,
-        output_prefix,
-        input_prefix
+    s3_bucket_and_region,
+    pipeline_s3_objects_main,
+    pipeline_s3_client_main,
+    test_input_dir_s3,
+    test_output_dir_s3,
+    output_prefix,
+    input_prefix
 ):
     """Test that the encoder runs with S3 input and output paths and outputs the correct files."""
 
@@ -95,13 +93,13 @@ def test_run_encoder_s3(
     assert len(files) == len(pipeline_s3_objects_main) * 2
 
     assert set(files) == {
-            f'{output_prefix}/test_html.json',
-            f'{output_prefix}/test_html.npy',
-            f'{output_prefix}/test_no_content_type.json',
-            f'{output_prefix}/test_no_content_type.npy',
-            f'{output_prefix}/test_pdf.json',
-            f'{output_prefix}/test_pdf.npy',
-        }
+        f'{output_prefix}/test_html.json',
+        f'{output_prefix}/test_html.npy',
+        f'{output_prefix}/test_no_content_type.json',
+        f'{output_prefix}/test_no_content_type.npy',
+        f'{output_prefix}/test_pdf.json',
+        f'{output_prefix}/test_pdf.npy',
+    }
 
     s3_files_json = [file for file in files if file.endswith('.json')]
     s3_files_npy = [file for file in files if file.endswith('.npy')]
@@ -110,10 +108,10 @@ def test_run_encoder_s3(
     assert len(s3_files_npy) == len(pipeline_s3_objects_main)
 
     for file in s3_files_json:
-            file_obj = pipeline_s3_client_main.client.get_object(Bucket=s3_bucket_and_region['bucket'], Key=file)
-            file_text = file_obj["Body"].read().decode("utf-8")
-            file_json = json.loads(file_text)
-            assert IndexerInput.parse_obj(file_json)
+        file_obj = pipeline_s3_client_main.client.get_object(Bucket=s3_bucket_and_region['bucket'], Key=file)
+        file_text = file_obj["Body"].read().decode("utf-8")
+        file_json = json.loads(file_text)
+        assert IndexerInput.parse_obj(file_json)
 
     for file in s3_files_npy:
         file_obj = pipeline_s3_client_main.client.get_object(Bucket=s3_bucket_and_region['bucket'], Key=file)
@@ -122,7 +120,7 @@ def test_run_encoder_s3(
 
 
 def test_run_parser_skip_already_done(
-        test_html_file_json, test_pdf_file_json, test_no_content_type_file_json, caplog
+    test_html_file_json, test_pdf_file_json, test_no_content_type_file_json, caplog
 ) -> None:
     """Test that files which have already been parsed are skipped by default."""
 


### PR DESCRIPTION
### Npy File Bugfix

We realised during a pipeline run that the embeddings generation was not functioning as expected. 

It was realised that when pushing to s3 the npy data was incorrect. This slipped through the tests as the embeddings repo unit test only assert the correct numpy format for a local run of the text2embeddings program (we saved data in a different way for aws vs local runs). The pipeline integration tests then only asserted that the correct numpy files existed but didn't actually check the content. 

To solve this:
- Updated the unit tests, realised that we weren't actually running any tasks through embeddings generation for the s3 test as the mock s3 client bucket didn't have the files loaded correctly. 
- Added a [failing test](https://github.com/climatepolicyradar/navigator-embeddings-generation/actions/runs/5588639959/jobs/10215728713)
- Made code changes to resolve the failing test. 
    - This was done by saving to a temp file with np.save and then uploading this to s3 with boto3. 