### PR TITLE
make embeddings generation function importable

### DIFF
--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -99,8 +99,32 @@ def run_as_cli(
     encoding for files that have already been parsed. By default, files with IDs that
     already exist in the output directory are skipped. limit (Optional[int]):
     Optionally limit the number of text samples to process. Useful for debugging.
-    device (str): Device to use for embeddings generation. Must be either "cuda", "mps", 
+    device (str): Device to use for embeddings generation. Must be either "cuda", "mps",
     or "cpu".
+    """
+
+    return run_embeddings_generation(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        s3=s3,
+        redo=redo,
+        device=device,
+        limit=limit,
+    )
+
+
+def run_embeddings_generation(
+    input_dir: str,
+    output_dir: str,
+    s3: bool,
+    redo: bool,
+    device: str,
+    limit: Optional[int],
+):
+    """
+    Run CLI to produce embeddings from document parser JSON outputs.
+
+    See docstring for run_as_cli for details.
     """
     # FIXME: This solution assumes that we have a json document with language = en (
     #  supported target language) for every document in the parser output. This isn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["CPR Tech <tech@climatepolicyradar.org>"]
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python = "^3.9"
 sentence-transformers = "^2.2.0"
 huggingface_hub = ">=0.14.0,<1.0.0"
 click = "^8.0.4"


### PR DESCRIPTION
enables the following. no tests added as there weren't any end-to-end tests for the CLI in there to adapt to this function

``` py
from navigator_embeddings_generation.cli import run_embeddings_generation

run_embeddings_generation(*args, **kwargs)
```

@THOR300 it'd also be good if i could make a release after this is merged for install reasons, but let me know if that woudl cause an issue with the pipeline