### PR TITLE
refactor(dependabot): Group all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: pip
+    commit-message:
+      prefix: feat
+      include: scope
+    groups:
+       all:
+         applies-to: version-updates
+         patterns:
+           - "*"
     directory: /
     schedule:
       interval: monthly
@@ -9,6 +17,14 @@ updates:
     reviewers:
       - climatepolicyradar/deng
   - package-ecosystem: github-actions
+    commit-message:
+      prefix: feat
+      include: scope
+    groups:
+       all:
+         applies-to: version-updates
+         patterns:
+           - "*"
     directory: /
     schedule:
       interval: monthly
@@ -17,6 +33,14 @@ updates:
     reviewers:
       - climatepolicyradar/deng
   - package-ecosystem: pip
+    commit-message:
+      prefix: feat
+      include: scope
+    groups:
+       all:
+         applies-to: version-updates
+         patterns:
+           - "*"
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
I've added a prefix too [1], so we can have nicer release notes.

This uses the same naive grouping approach as in other repositories [2].

FIXES PLA-173

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message
[2] https://github.com/climatepolicyradar/navigator-data-pipeline/pull/224/files