### PR TITLE
Feature/pla 1016 refactor embeddings job improve observability

### DIFF
--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -118,7 +118,7 @@ def process_task(
         )
 
         # Step 5: Save embeddings
-        embeddings_output_path = os.path.join(output_dir, document_id + ".npy")
+        embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
         if not s3:
             Path(embeddings_output_path).parent.mkdir(parents=True, exist_ok=True)
         (
@@ -128,7 +128,7 @@ def process_task(
         )
 
         # Step 6: Save document JSON
-        task_output_path = os.path.join(output_dir, document_id + ".json")
+        task_output_path = os.path.join(output_dir, task.document_id + ".json")
         if not s3:
             Path(task_output_path).parent.mkdir(parents=True, exist_ok=True)
         (

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -53,7 +53,7 @@ class EmbeddingResult(BaseModel):
     error: Optional[str] = None
 
 
-def process_task(
+def process_document(
     document_id: DocumentImportId,
     encoder: SBERTEncoder,
     input_dir: str,
@@ -90,25 +90,28 @@ def process_task(
         json_content = (
             s3_object_read_text(file_path) if s3 else Path(file_path).read_text()
         )
-        task = ParserOutput.model_validate_json(json_content)
+        parser_output = ParserOutput.model_validate_json(json_content)
 
         # Step 2: Check if language is supported
-        # get_docs_of_supported_language expects a list, so we wrap and unwrap
-        supported_tasks = get_docs_of_supported_language([task])
-        if not supported_tasks:
+        parser_outputs_with_supported_lang: list[
+            ParserOutput
+        ] = get_docs_of_supported_language([parser_output])
+        if not parser_outputs_with_supported_lang:
             result.error = "Filtered out: unsupported language"
             return result
-        task = supported_tasks[0]
+        parser_output = parser_outputs_with_supported_lang[0]
 
         # Step 3: Filter unwanted text block types
-        filtered_tasks = filter_on_block_type(
-            inputs=[task], remove_block_types=config.BLOCKS_TO_FILTER
+        parser_outputs_with_filtered_text_blocks: list[
+            ParserOutput
+        ] = filter_on_block_type(
+            inputs=[parser_output], remove_block_types=config.BLOCKS_TO_FILTER
         )
-        task = filtered_tasks[0]
+        parser_output = parser_outputs_with_filtered_text_blocks[0]
 
         # Step 4: Generate embeddings
         description_embedding, text_embeddings = encode_parser_output(
-            encoder, task, config.ENCODING_BATCH_SIZE, device=device
+            encoder, parser_output, config.ENCODING_BATCH_SIZE, device=device
         )
 
         combined_embeddings = (
@@ -118,23 +121,31 @@ def process_task(
         )
 
         # Step 5: Save embeddings
-        embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
+        embeddings_output_path_npy = os.path.join(
+            output_dir, parser_output.document_id + ".npy"
+        )
         if not s3:
-            Path(embeddings_output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(embeddings_output_path_npy).parent.mkdir(parents=True, exist_ok=True)
         (
-            save_ndarray_to_s3_as_npy(combined_embeddings, embeddings_output_path)
+            save_ndarray_to_s3_as_npy(combined_embeddings, embeddings_output_path_npy)
             if s3
-            else np.save(embeddings_output_path, combined_embeddings)
+            else np.save(embeddings_output_path_npy, combined_embeddings)
         )
 
         # Step 6: Save document JSON
-        task_output_path = os.path.join(output_dir, task.document_id + ".json")
+        embeddings_output_path_json = os.path.join(
+            output_dir, parser_output.document_id + ".json"
+        )
         if not s3:
-            Path(task_output_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(embeddings_output_path_json).parent.mkdir(parents=True, exist_ok=True)
         (
-            write_json_to_s3(task.model_dump_json(indent=2), task_output_path)
+            write_json_to_s3(
+                parser_output.model_dump_json(indent=2), embeddings_output_path_json
+            )
             if s3
-            else Path(task_output_path).write_text(task.model_dump_json(indent=2))
+            else Path(embeddings_output_path_json).write_text(
+                parser_output.model_dump_json(indent=2)
+            )
         )
 
     except Exception as e:
@@ -289,7 +300,7 @@ def run_embeddings_generation(
     results: list[EmbeddingResult] = []
 
     for document_id in tqdm(document_import_ids, unit="docs"):
-        result = process_task(
+        result = process_document(
             document_id=document_id,
             encoder=encoder,
             input_dir=embeddings_input_dir_path,

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -17,12 +17,8 @@ from tqdm.auto import tqdm
 from src import config
 from src.languages import get_docs_of_supported_language
 from src.ml import SBERTEncoder
-from src.s3 import save_ndarray_to_s3_as_npy, write_json_to_s3
-from src.utils import (
-    encode_parser_output,
-    filter_on_block_type,
-    get_Text2EmbeddingsInput_array,
-)
+from src.s3 import s3_object_read_text, save_ndarray_to_s3_as_npy, write_json_to_s3
+from src.utils import encode_parser_output, filter_on_block_type
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 DEFAULT_LOGGING = {
@@ -58,48 +54,98 @@ class EmbeddingResult(BaseModel):
 
 
 def process_task(
-    task: ParserOutput,
+    document_id: DocumentImportId,
     encoder: SBERTEncoder,
+    input_dir: str,
     output_dir: str,
     s3: bool,
     device: str,
-) -> None:
+) -> EmbeddingResult:
     """
-    Process a single task to generate embeddings.
+    Process a single document end-to-end: load, validate, filter, encode, and save.
+
+    This function handles all steps for a single document:
+    1. Load document from S3 or local filesystem
+    2. Check if language is supported
+    3. Filter unwanted text block types
+    4. Generate embeddings
+    5. Save embeddings and document JSON
 
     Args:
-        task: The parser output task to process
+        document_id: The document import ID to process
         encoder: The sentence encoder to use
+        input_dir: Directory containing input JSON files
         output_dir: Directory to save outputs to
         s3: Whether to use S3 for I/O
         device: Device to use for encoding
+
+    Returns:
+        EmbeddingResult with document_id and optional error message
     """
+    result = EmbeddingResult(document_id=document_id)
 
-    description_embedding, text_embeddings = encode_parser_output(
-        encoder, task, config.ENCODING_BATCH_SIZE, device=device
-    )
+    try:
+        # Step 1: Load document
+        file_path = os.path.join(input_dir, document_id + ".json")
+        json_content = (
+            s3_object_read_text(file_path) if s3 else Path(file_path).read_text()
+        )
+        task = ParserOutput.model_validate_json(json_content)
 
-    combined_embeddings = (
-        np.vstack([description_embedding, text_embeddings])
-        if text_embeddings is not None
-        else description_embedding.reshape(1, -1)
-    )
+        # Step 2: Check if language is supported
+        # get_docs_of_supported_language expects a list, so we wrap and unwrap
+        supported_tasks = get_docs_of_supported_language([task])
+        if not supported_tasks:
+            result.error = "Filtered out: unsupported language"
+            return result
+        task = supported_tasks[0]
 
-    embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
+        # Step 3: Filter unwanted text block types
+        filtered_tasks = filter_on_block_type(
+            inputs=[task], remove_block_types=config.BLOCKS_TO_FILTER
+        )
+        task = filtered_tasks[0]
 
-    (
-        save_ndarray_to_s3_as_npy(combined_embeddings, embeddings_output_path)
-        if s3
-        else np.save(embeddings_output_path, combined_embeddings)
-    )
+        # Step 4: Generate embeddings
+        description_embedding, text_embeddings = encode_parser_output(
+            encoder, task, config.ENCODING_BATCH_SIZE, device=device
+        )
 
-    task_output_path = os.path.join(output_dir, task.document_id + ".json")
+        combined_embeddings = (
+            np.vstack([description_embedding, text_embeddings])
+            if text_embeddings is not None
+            else description_embedding.reshape(1, -1)
+        )
 
-    (
-        write_json_to_s3(task.model_dump_json(indent=2), task_output_path)
-        if s3
-        else Path(task_output_path).write_text(task.model_dump_json(indent=2))
-    )
+        # Step 5: Save embeddings
+        embeddings_output_path = os.path.join(output_dir, document_id + ".npy")
+        if not s3:
+            Path(embeddings_output_path).parent.mkdir(parents=True, exist_ok=True)
+        (
+            save_ndarray_to_s3_as_npy(combined_embeddings, embeddings_output_path)
+            if s3
+            else np.save(embeddings_output_path, combined_embeddings)
+        )
+
+        # Step 6: Save document JSON
+        task_output_path = os.path.join(output_dir, document_id + ".json")
+        if not s3:
+            Path(task_output_path).parent.mkdir(parents=True, exist_ok=True)
+        (
+            write_json_to_s3(task.model_dump_json(indent=2), task_output_path)
+            if s3
+            else Path(task_output_path).write_text(task.model_dump_json(indent=2))
+        )
+
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {str(e)}"
+        logger.exception(
+            f"Processing document {document_id} failed",
+            extra={"props": {"document_id": document_id}},
+        )
+        result.error = error_msg
+
+    return result
 
 
 def write_results_file(
@@ -224,68 +270,49 @@ def run_embeddings_generation(
         },
     )
 
-    logger.info("Constructing Text2EmbeddingsInput objects from parser output jsons.")
-    tasks = get_Text2EmbeddingsInput_array(
-        embeddings_input_dir_path, s3, document_import_ids
-    )
-
-    logger.info(
-        "Filtering tasks to those with supported languages.",
-        extra={"props": {"target_languages": config.TARGET_LANGUAGES}},
-    )
-    tasks = get_docs_of_supported_language(tasks)
-    logger.info(
-        f"Found {len(tasks)} tasks with supported languages.",
-        extra={
-            "props": {
-                "tasks": [
-                    {
-                        "lang": task.languages,
-                        "translated": task.translated,
-                        "document_id": task.document_id,
-                    }
-                    for task in tasks
-                ]
-            }
-        },
-    )
-
-    logger.info(
-        "Filtering unwanted text block types.",
-        extra={"props": {"BLOCKS_TO_FILTER": config.BLOCKS_TO_FILTER}},
-    )
-    tasks = filter_on_block_type(
-        inputs=tasks, remove_block_types=config.BLOCKS_TO_FILTER
-    )
-
     logger.info(f"Loading sentence-transformer model {config.SBERT_MODEL}")
     encoder = SBERTEncoder(config.SBERT_MODEL)
 
     logger.info(
-        "Encoding text from documents.",
+        "Processing documents.",
         extra={
             "props": {
                 "ENCODING_BATCH_SIZE": config.ENCODING_BATCH_SIZE,
-                "tasks_number": len(tasks),
+                "total_documents": len(document_import_ids),
+                "target_languages": config.TARGET_LANGUAGES,
+                "blocks_to_filter": config.BLOCKS_TO_FILTER,
             }
         },
     )
 
+    # Process each document independently
     results: list[EmbeddingResult] = []
 
-    for task in tqdm(tasks, unit="docs"):
-        result = EmbeddingResult(document_id=task.document_id)
-
-        try:
-            process_task(task, encoder, embeddings_output_dir_path, s3, device)
-        except Exception as e:
-            msg = f"Processing document {task.document_id} failed: {e}"
-            logger.exception(msg, extra={"props": {"document_id": task.document_id}})
-            result.error = f"{type(e).__name__}: {str(e)}"
-
+    for document_id in tqdm(document_import_ids, unit="docs"):
+        result = process_task(
+            document_id=document_id,
+            encoder=encoder,
+            input_dir=embeddings_input_dir_path,
+            output_dir=embeddings_output_dir_path,
+            s3=s3,
+            device=device,
+        )
         results.append(result)
 
-    logger.info("Done processing documents.")
+    # Log summary statistics
+    successful = sum(1 for r in results if r.error is None)
+    failed = len(results) - successful
+
+    logger.info(
+        "Done processing documents.",
+        extra={
+            "props": {
+                "total": len(results),
+                "successful": successful,
+                "failed": failed,
+            }
+        },
+    )
 
     # Write out results
     write_results_file(results, input_dir_path, s3)

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from tqdm.auto import tqdm
 
 from src import config
-from src.languages import get_docs_of_supported_language
+from src.languages import doc_has_supported_language
 from src.ml import SBERTEncoder
 from src.s3 import s3_object_read_text, save_ndarray_to_s3_as_npy, write_json_to_s3
 from src.utils import encode_parser_output, filter_on_block_type
@@ -93,21 +93,14 @@ def process_document(
         parser_output = ParserOutput.model_validate_json(json_content)
 
         # Step 2: Check if language is supported
-        parser_outputs_with_supported_lang: list[
-            ParserOutput
-        ] = get_docs_of_supported_language([parser_output])
-        if not parser_outputs_with_supported_lang:
+        if not doc_has_supported_language(parser_output):
             result.error = "Filtered out: unsupported language"
             return result
-        parser_output = parser_outputs_with_supported_lang[0]
 
         # Step 3: Filter unwanted text block types
-        parser_outputs_with_filtered_text_blocks: list[
-            ParserOutput
-        ] = filter_on_block_type(
-            inputs=[parser_output], remove_block_types=config.BLOCKS_TO_FILTER
+        parser_output: ParserOutput = filter_on_block_type(
+            document=parser_output, remove_block_types=config.BLOCKS_TO_FILTER
         )
-        parser_output = parser_outputs_with_filtered_text_blocks[0]
 
         # Step 4: Generate embeddings
         description_embedding, text_embeddings = encode_parser_output(

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -6,6 +6,7 @@ import logging.config
 import os
 from pathlib import Path
 from typing import NewType, Optional
+from uuid import uuid4
 
 import click
 import numpy as np
@@ -102,17 +103,20 @@ def process_task(
 
 
 def write_results_file(
-    results: list[EmbeddingResult], output_dir: str, s3: bool
+    results: list[EmbeddingResult], input_dir_path: str, s3: bool
 ) -> None:
     """
     Write results to a JSON file.
 
     Args:
-        results: List of embedding results
-        output_dir: Directory to write results file to
-        s3: Whether to write to S3
+        results: List of embedding results.
+        input_dir_path: Directory to write results file to that is specific to the run.
+        s3: Whether to write to S3.
     """
-    results_path = os.path.join(output_dir, "embeddings_results.json")
+    results_path = os.path.join(
+        input_dir_path, "reports", "embeddings", uuid4().hex + ".json"
+    )
+
     results_json = json.dumps(
         [result.model_dump() for result in results],
         indent=2,
@@ -137,12 +141,9 @@ class CommaSeparatedList(click.ParamType):
 
 
 @click.command()
-@click.argument(
-    "input-dir",
-)
-@click.argument(
-    "output-dir",
-)
+@click.argument("input-dir-path")
+@click.argument("embeddings-input-dir")
+@click.argument("embeddings-output-dir")
 @click.argument("document-import-ids", type=CommaSeparatedList())
 @click.option(
     "--s3",
@@ -158,8 +159,9 @@ class CommaSeparatedList(click.ParamType):
     default="cpu",
 )
 def run_as_cli(
-    input_dir: str,
-    output_dir: str,
+    input_dir_path: str,
+    embeddings_input_dir_path: str,
+    embeddings_output_dir_path: str,
     document_import_ids: list[DocumentImportId],
     s3: bool,
     device: str,
@@ -172,15 +174,21 @@ def run_as_cli(
     embeddings of each of the text blocks in the document in order. Encoding will
     run CPU unless device is set to 'cuda' or 'mps'.
 
-    Args: input_dir: Directory containing JSON files output_dir: Directory to save
-    embeddings to s3: Whether we are reading from and writing to S3.
-    document_import_ids: A list of the document import ids to run on. device (str):
-    Device to use for embeddings generation. Must be either "cuda", "mps", or "cpu".
+    Args:
+        input_dir_path: Directory containing the input directory for the run.
+        embeddings_input_dir_path: Directory containing JSON files to process for embeddings
+            generation.
+        embeddings_output_dir_path: Directory to save embeddings to.
+        document_import_ids: A list of the document import ids to run on.
+        s3: Whether we are reading from and writing to S3.
+        device: Device to use for embeddings generation.
+            Must be either "cuda", "mps", or "cpu".
     """
 
     return run_embeddings_generation(
-        input_dir=input_dir,
-        output_dir=output_dir,
+        input_dir_path=input_dir_path,
+        embeddings_input_dir_path=embeddings_input_dir_path,
+        embeddings_output_dir_path=embeddings_output_dir_path,
         document_import_ids=document_import_ids,
         s3=s3,
         device=device,
@@ -188,8 +196,9 @@ def run_as_cli(
 
 
 def run_embeddings_generation(
-    input_dir: str,
-    output_dir: str,
+    input_dir_path: str,
+    embeddings_input_dir_path: str,
+    embeddings_output_dir_path: str,
     document_import_ids: list[DocumentImportId],
     s3: bool,
     device: str,
@@ -204,8 +213,9 @@ def run_embeddings_generation(
         "Running embeddings generation...",
         extra={
             "props": {
-                "input_dir": input_dir,
-                "output_dir": output_dir,
+                "input_dir_path": input_dir_path,
+                "embeddings_input_dir_path": embeddings_input_dir_path,
+                "embeddings_output_dir_path": embeddings_output_dir_path,
                 "document_import_ids": document_import_ids,
                 "s3": s3,
                 "device": device,
@@ -214,7 +224,9 @@ def run_embeddings_generation(
     )
 
     logger.info("Constructing Text2EmbeddingsInput objects from parser output jsons.")
-    tasks = get_Text2EmbeddingsInput_array(input_dir, s3, document_import_ids)
+    tasks = get_Text2EmbeddingsInput_array(
+        embeddings_input_dir_path, s3, document_import_ids
+    )
 
     logger.info(
         "Filtering tasks to those with supported languages.",
@@ -264,7 +276,7 @@ def run_embeddings_generation(
         result = EmbeddingResult(document_id=task.document_id)
 
         try:
-            process_task(task, encoder, output_dir, s3, device)
+            process_task(task, encoder, embeddings_output_dir_path, s3, device)
         except Exception as e:
             msg = f"Processing document {task.document_id} failed: {e}"
             logger.exception(msg, extra={"props": {"document_id": task.document_id}})
@@ -275,7 +287,7 @@ def run_embeddings_generation(
     logger.info("Done processing documents.")
 
     # Write out results
-    write_results_file(results, output_dir, s3)
+    write_results_file(results, input_dir_path, s3)
 
 
 if __name__ == "__main__":

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -1,24 +1,27 @@
 """CLI to convert JSON documents outputted by the PDF parsing pipeline to embeddings."""
 
+import json
 import logging
 import logging.config
 import os
 from pathlib import Path
+from typing import NewType, Optional
 
 import click
 import numpy as np
+from cpr_sdk.parser_models import ParserOutput
+from pydantic import BaseModel
 from tqdm.auto import tqdm
-from typing import NewType
 
+from src import config
 from src.languages import get_docs_of_supported_language
 from src.ml import SBERTEncoder
-from src import config
+from src.s3 import check_file_exists_in_s3, save_ndarray_to_s3_as_npy, write_json_to_s3
 from src.utils import (
-    filter_on_block_type,
     encode_parser_output,
+    filter_on_block_type,
     get_Text2EmbeddingsInput_array,
 )
-from src.s3 import check_file_exists_in_s3, write_json_to_s3, save_ndarray_to_s3_as_npy
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 DEFAULT_LOGGING = {
@@ -44,6 +47,92 @@ logging.config.dictConfig(DEFAULT_LOGGING)
 
 # Example: CCLW.executive.1813.2418
 DocumentImportId = NewType("DocumentImportId", str)
+
+
+class EmbeddingResult(BaseModel):
+    """Result of processing a document for embeddings generation."""
+
+    document_id: str
+    error: Optional[str] = None
+
+
+def process_task(
+    task: ParserOutput,
+    encoder: SBERTEncoder,
+    output_dir: str,
+    s3: bool,
+    device: str,
+) -> None:
+    """
+    Process a single task to generate embeddings.
+
+    Args:
+        task: The parser output task to process
+        encoder: The sentence encoder to use
+        output_dir: Directory to save outputs to
+        s3: Whether to use S3 for I/O
+        device: Device to use for encoding
+    """
+    task_output_path = os.path.join(output_dir, task.document_id + ".json")
+
+    (
+        write_json_to_s3(task.model_dump_json(indent=2), task_output_path)
+        if s3
+        else Path(task_output_path).write_text(task.model_dump_json(indent=2))
+    )
+
+    embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
+
+    file_exists = (
+        check_file_exists_in_s3(embeddings_output_path)
+        if s3
+        else os.path.exists(embeddings_output_path)
+    )
+    if file_exists:
+        logger.info(
+            f"Embeddings output file '{embeddings_output_path}' already exists, "
+            "skipping processing."
+        )
+        return
+
+    description_embedding, text_embeddings = encode_parser_output(
+        encoder, task, config.ENCODING_BATCH_SIZE, device=device
+    )
+
+    combined_embeddings = (
+        np.vstack([description_embedding, text_embeddings])
+        if text_embeddings is not None
+        else description_embedding.reshape(1, -1)
+    )
+
+    (
+        save_ndarray_to_s3_as_npy(combined_embeddings, embeddings_output_path)
+        if s3
+        else np.save(embeddings_output_path, combined_embeddings)
+    )
+
+
+def write_results_file(
+    results: list[EmbeddingResult], output_dir: str, s3: bool
+) -> None:
+    """
+    Write results to a JSON file.
+
+    Args:
+        results: List of embedding results
+        output_dir: Directory to write results file to
+        s3: Whether to write to S3
+    """
+    results_path = os.path.join(output_dir, "embeddings_results.json")
+    results_json = json.dumps(
+        [result.model_dump() for result in results],
+        indent=2,
+    )
+
+    if s3:
+        write_json_to_s3(results_json, results_path)
+    else:
+        Path(results_path).write_text(results_json)
 
 
 class CommaSeparatedList(click.ParamType):
@@ -179,48 +268,25 @@ def run_embeddings_generation(
             }
         },
     )
+
+    results: list[EmbeddingResult] = []
+
     for task in tqdm(tasks, unit="docs"):
-        task_output_path = os.path.join(output_dir, task.document_id + ".json")
+        result = EmbeddingResult(document_id=task.document_id)
 
         try:
-            write_json_to_s3(
-                task.model_dump_json(indent=2), task_output_path
-            ) if s3 else Path(task_output_path).write_text(
-                task.model_dump_json(indent=2)
-            )
+            process_task(task, encoder, output_dir, s3, device)
         except Exception as e:
-            logger.info(
-                "Failed to write embeddings data to s3.",
-                extra={"props": {"task_output_path": task_output_path, "exception": e}},
-            )
+            msg = f"Processing document {task.document_id} failed: {e}"
+            logger.exception(msg, extra={"props": {"document_id": task.document_id}})
+            result.error = f"{type(e).__name__}: {str(e)}"
 
-        embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
+        results.append(result)
 
-        file_exists = (
-            check_file_exists_in_s3(embeddings_output_path)
-            if s3
-            else os.path.exists(embeddings_output_path)
-        )
-        if file_exists:
-            logger.info(
-                f"Embeddings output file '{embeddings_output_path}' already exists, "
-                "skipping processing."
-            )
-            continue
+    logger.info("Done processing documents.")
 
-        description_embedding, text_embeddings = encode_parser_output(
-            encoder, task, config.ENCODING_BATCH_SIZE, device=device
-        )
-
-        combined_embeddings = (
-            np.vstack([description_embedding, text_embeddings])
-            if text_embeddings is not None
-            else description_embedding.reshape(1, -1)
-        )
-
-        save_ndarray_to_s3_as_npy(
-            combined_embeddings, embeddings_output_path
-        ) if s3 else np.save(embeddings_output_path, combined_embeddings)
+    # Write out results
+    write_results_file(results, output_dir, s3)
 
 
 if __name__ == "__main__":

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -125,6 +125,7 @@ def write_results_file(
     if s3:
         write_json_to_s3(results_json, results_path)
     else:
+        Path(results_path).parent.mkdir(parents=True, exist_ok=True)
         Path(results_path).write_text(results_json)
 
 
@@ -142,8 +143,8 @@ class CommaSeparatedList(click.ParamType):
 
 @click.command()
 @click.argument("input-dir-path")
-@click.argument("embeddings-input-dir")
-@click.argument("embeddings-output-dir")
+@click.argument("embeddings-input-dir-path")
+@click.argument("embeddings-output-dir-path")
 @click.argument("document-import-ids", type=CommaSeparatedList())
 @click.option(
     "--s3",

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -16,7 +16,7 @@ from tqdm.auto import tqdm
 from src import config
 from src.languages import get_docs_of_supported_language
 from src.ml import SBERTEncoder
-from src.s3 import check_file_exists_in_s3, save_ndarray_to_s3_as_npy, write_json_to_s3
+from src.s3 import save_ndarray_to_s3_as_npy, write_json_to_s3
 from src.utils import (
     encode_parser_output,
     filter_on_block_type,
@@ -73,27 +73,6 @@ def process_task(
         s3: Whether to use S3 for I/O
         device: Device to use for encoding
     """
-    task_output_path = os.path.join(output_dir, task.document_id + ".json")
-
-    (
-        write_json_to_s3(task.model_dump_json(indent=2), task_output_path)
-        if s3
-        else Path(task_output_path).write_text(task.model_dump_json(indent=2))
-    )
-
-    embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
-
-    file_exists = (
-        check_file_exists_in_s3(embeddings_output_path)
-        if s3
-        else os.path.exists(embeddings_output_path)
-    )
-    if file_exists:
-        logger.info(
-            f"Embeddings output file '{embeddings_output_path}' already exists, "
-            "skipping processing."
-        )
-        return
 
     description_embedding, text_embeddings = encode_parser_output(
         encoder, task, config.ENCODING_BATCH_SIZE, device=device
@@ -105,10 +84,20 @@ def process_task(
         else description_embedding.reshape(1, -1)
     )
 
+    embeddings_output_path = os.path.join(output_dir, task.document_id + ".npy")
+
     (
         save_ndarray_to_s3_as_npy(combined_embeddings, embeddings_output_path)
         if s3
         else np.save(embeddings_output_path, combined_embeddings)
+    )
+
+    task_output_path = os.path.join(output_dir, task.document_id + ".json")
+
+    (
+        write_json_to_s3(task.model_dump_json(indent=2), task_output_path)
+        if s3
+        else Path(task_output_path).write_text(task.model_dump_json(indent=2))
     )
 
 

--- a/src/languages.py
+++ b/src/languages.py
@@ -50,10 +50,8 @@ def document_has_no_source_url_languages_or_data(document: ParserOutput) -> bool
 
 
 @validate_languages_decorator
-def get_docs_of_supported_language(
-    documents: List[ParserOutput],
-) -> List[ParserOutput]:
-    """Filter out documents that don't meet language requirements.
+def doc_has_supported_language(document: ParserOutput) -> bool:
+    """Identify documents that don't meet language requirements.
 
     Empty documents that have a source url will have a translated output produced for
     them by the pdf parser with a language that is supported by the encoder. Thus,
@@ -61,9 +59,8 @@ def get_docs_of_supported_language(
     encode the root non-translated document as well. This is why we have the
     document_has_one_lang_that_is_supported function.
     """
-    return [
+    if document_has_one_lang_that_is_supported(
         document
-        for document in documents
-        if document_has_one_lang_that_is_supported(document)
-        or document_has_no_source_url_languages_or_data(document)
-    ]
+    ) or document_has_no_source_url_languages_or_data(document):
+        return True
+    return False

--- a/src/languages.py
+++ b/src/languages.py
@@ -27,31 +27,31 @@ def validate_languages_decorator(func):
     return wrapper
 
 
-def task_has_one_lang_that_is_supported(task: ParserOutput) -> bool:
-    """Return true if the task has one language that is supported by the encoder."""
+def document_has_one_lang_that_is_supported(document: ParserOutput) -> bool:
+    """Return true if the document has one language that is supported by the encoder."""
     return (
-        task.languages
-        and (len(task.languages) == 1)
+        document.languages
+        and (len(document.languages) == 1)
         and (
-            task.languages[0]
+            document.languages[0]
             in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
         )
     )
 
 
-def task_has_no_source_url_languages_or_data(task: ParserOutput) -> bool:
-    """Return true if the task has no source url, languages or html/pdf data."""
+def document_has_no_source_url_languages_or_data(document: ParserOutput) -> bool:
+    """Return true if the document has no source url, languages or html/pdf data."""
     return (
-        not task.document_source_url
-        and not task.languages
-        and task.html_data is None
-        and task.pdf_data is None
+        not document.document_source_url
+        and not document.languages
+        and document.html_data is None
+        and document.pdf_data is None
     )
 
 
 @validate_languages_decorator
 def get_docs_of_supported_language(
-    tasks: List[ParserOutput],
+    documents: List[ParserOutput],
 ) -> List[ParserOutput]:
     """Filter out documents that don't meet language requirements.
 
@@ -59,11 +59,11 @@ def get_docs_of_supported_language(
     them by the pdf parser with a language that is supported by the encoder. Thus,
     we want to filter the root documents out (with no language) as we don't want to
     encode the root non-translated document as well. This is why we have the
-    task_has_one_lang_that_is_supported function.
+    document_has_one_lang_that_is_supported function.
     """
     return [
-        task
-        for task in tasks
-        if task_has_one_lang_that_is_supported(task)
-        or task_has_no_source_url_languages_or_data(task)
+        document
+        for document in documents
+        if document_has_one_lang_that_is_supported(document)
+        or document_has_no_source_url_languages_or_data(document)
     ]

--- a/src/languages.py
+++ b/src/languages.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from cpr_sdk.parser_models import ParserOutput
 

--- a/src/s3.py
+++ b/src/s3.py
@@ -4,7 +4,6 @@ from typing import Any
 import boto3
 import numpy as np
 from aws_error_utils.aws_error_utils import errors
-from botocore.exceptions import ClientError
 
 from src.config import S3_PATTERN
 
@@ -18,24 +17,6 @@ def validate_s3_pattern(s3_path: str):
     key = s3_match.group("prefix")
     s3client = boto3.client("s3")
     return bucket, key, s3client
-
-
-# TODO do we want to instantiate one client object and pass that through rather than
-#  instantiating each time?
-def check_file_exists_in_s3(s3_path: str) -> bool:
-    """Checks whether a file exists in an S3 bucket."""
-    bucket, key, s3client = validate_s3_pattern(s3_path)
-    try:
-        s3client.head_object(Bucket=bucket, Key=key)
-        return True
-    except ClientError:
-        return False
-    except errors.NoSuchBucket:
-        return False
-    except errors.NoSuchKey:
-        return False
-    except Exception as e:
-        raise e
 
 
 def s3_object_read_text(s3_path: str) -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -47,14 +47,9 @@ def filter_blocks(
 
 
 def filter_on_block_type(
-    inputs: Sequence[ParserOutput], remove_block_types: List[str]
-) -> Sequence[ParserOutput]:
-    """
-    Filter a sequence of ParserOutputs.
-
-    Remove the text blocks that are of the types declared in the remove block types
-    array.
-    """
+    document: ParserOutput, remove_block_types: List[str]
+) -> ParserOutput:
+    """Remove the text blocks of the types declared in the remove block types array."""
     for _filter in remove_block_types:
         try:
             BlockType(_filter)
@@ -65,15 +60,12 @@ def filter_on_block_type(
             )
             remove_block_types.remove(_filter)
 
-    return [
-        replace_text_blocks(
-            block=_input,
-            new_text_blocks=filter_blocks(
-                parser_output=_input, remove_block_types=remove_block_types
-            ),
-        )
-        for _input in inputs
-    ]
+    return replace_text_blocks(
+        block=document,
+        new_text_blocks=filter_blocks(
+            parser_output=document, remove_block_types=remove_block_types
+        ),
+    )
 
 
 def encode_parser_output(

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,13 +1,10 @@
 import logging
-import os
-from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 from cpr_sdk.parser_models import BlockType, ParserOutput, TextBlock
 
 from src.ml import SentenceEncoder
-from src.s3 import s3_object_read_text
 
 logger = logging.getLogger(__name__)
 
@@ -113,21 +110,3 @@ def encode_parser_output(
         text_embeddings = None
 
     return description_embedding, text_embeddings
-
-
-def get_Text2EmbeddingsInput_array(
-    input_dir: str, s3: bool, files_to_process_ids: Sequence[str]
-) -> List[ParserOutput]:
-    """Construct ParserOutput objects from parser output jsons.
-
-    These objects will be used to generate embeddings and are either read in from S3
-    or from the local file system.
-    """
-    return [
-        ParserOutput.model_validate_json(
-            s3_object_read_text(os.path.join(input_dir, id_ + ".json"))
-            if s3
-            else Path(os.path.join(input_dir, id_ + ".json")).read_text()
-        )
-        for id_ in files_to_process_ids
-    ]

--- a/tests/cli/test_text2embeddings.py
+++ b/tests/cli/test_text2embeddings.py
@@ -17,47 +17,58 @@ def test_run_encoder_local(
 ):
     """Test that the encoder runs with local input and output paths and outputs the correct files."""
 
-    with tempfile.TemporaryDirectory() as input_dir:
-        with tempfile.TemporaryDirectory() as output_dir:
-            document_import_ids = []
+    with tempfile.TemporaryDirectory() as embeddings_input_dir_path:
+        with tempfile.TemporaryDirectory() as embeddings_output_dir_path:
+            with tempfile.TemporaryDirectory() as input_dir_path:
+                document_import_ids = []
 
-            # Create test files
-            for file in [
-                test_html_file_json,
-                test_pdf_file_json,
-                test_no_content_type_file_json,
-            ]:
-                file_path = Path(input_dir) / f"{file['document_id']}.json"
-                file_path.write_text(json.dumps(file))
+                # Create test files
+                for file in [
+                    test_html_file_json,
+                    test_pdf_file_json,
+                    test_no_content_type_file_json,
+                ]:
+                    file_path = (
+                        Path(embeddings_input_dir_path) / f"{file['document_id']}.json"
+                    )
+                    file_path.write_text(json.dumps(file))
 
-                document_import_ids.append(file["document_id"])
+                    document_import_ids.append(file["document_id"])
 
-            runner = CliRunner()
-            result = runner.invoke(
-                run_as_cli, [input_dir, output_dir, ",".join(document_import_ids)]
-            )
-            assert result.exit_code == 0
+                runner = CliRunner()
+                result = runner.invoke(
+                    run_as_cli,
+                    [
+                        input_dir_path,
+                        embeddings_input_dir_path,
+                        embeddings_output_dir_path,
+                        ",".join(document_import_ids),
+                    ],
+                )
+                assert result.exit_code == 0
 
-            assert set(Path(output_dir).glob("*.json")) == {
-                Path(output_dir) / "test_html.json",
-                Path(output_dir) / "test_pdf.json",
-                Path(output_dir) / "test_no_content_type.json",
-            }
-            assert set(Path(output_dir).glob("*.npy")) == {
-                Path(output_dir) / "test_html.npy",
-                Path(output_dir) / "test_pdf.npy",
-                Path(output_dir) / "test_no_content_type.npy",
-            }
+                assert set(Path(embeddings_output_dir_path).glob("*.json")) == {
+                    Path(embeddings_output_dir_path) / "test_html.json",
+                    Path(embeddings_output_dir_path) / "test_pdf.json",
+                    Path(embeddings_output_dir_path) / "test_no_content_type.json",
+                }
+                assert set(Path(embeddings_output_dir_path).glob("*.npy")) == {
+                    Path(embeddings_output_dir_path) / "test_html.npy",
+                    Path(embeddings_output_dir_path) / "test_pdf.npy",
+                    Path(embeddings_output_dir_path) / "test_no_content_type.npy",
+                }
 
-            for path in Path(output_dir).glob("*.json"):
-                assert ParserOutput.model_validate(json.loads(path.read_text()))
+                for path in Path(embeddings_output_dir_path).glob("*.json"):
+                    assert ParserOutput.model_validate(json.loads(path.read_text()))
 
-            for path in Path(output_dir).glob("*.npy"):
-                assert np.load(str(path)).shape[1] == 768
+                for path in Path(embeddings_output_dir_path).glob("*.npy"):
+                    assert np.load(str(path)).shape[1] == 768
 
-            # test_html has the `has_valid_text` flag set to false, so the numpy file
-            # should only contain a description embedding
-            assert np.load(str(Path(output_dir) / "test_html.npy")).shape == (1, 768)
+                # test_html has the `has_valid_text` flag set to false, so the numpy file
+                # should only contain a description embedding
+                assert np.load(
+                    str(Path(embeddings_output_dir_path) / "test_html.npy")
+                ).shape == (1, 768)
 
 
 def test_s3_client(
@@ -89,10 +100,20 @@ def test_run_encoder_s3(
         "CCLWTEST.executive.1002.1002",
     ]
 
+    input_dir_path: str = (
+        f's3://{s3_bucket_and_region["bucket"]}/input/2023-04-13T09.17.37.953810/'
+    )
+
     runner = CliRunner()
     result = runner.invoke(
         run_as_cli,
-        [test_input_dir_s3, test_output_dir_s3, ",".join(document_import_ids), "--s3"],
+        [
+            input_dir_path,
+            test_input_dir_s3,
+            test_output_dir_s3,
+            ",".join(document_import_ids),
+            "--s3",
+        ],
     )
 
     assert result.exit_code == 0

--- a/tests/cli/test_text2embeddings.py
+++ b/tests/cli/test_text2embeddings.py
@@ -2,12 +2,19 @@ import io
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 from click.testing import CliRunner
 from cpr_sdk.parser_models import ParserOutput
 
-from cli.text2embeddings import run_as_cli
+from cli.text2embeddings import (
+    EmbeddingResult,
+    process_document,
+    run_as_cli,
+    write_results_file,
+)
+from src.s3 import s3_object_read_text
 
 
 def test_run_encoder_local(
@@ -69,6 +76,29 @@ def test_run_encoder_local(
                 assert np.load(
                     str(Path(embeddings_output_dir_path) / "test_html.npy")
                 ).shape == (1, 768)
+
+                # Validate that results file is produced
+                results_dir = Path(input_dir_path) / "reports" / "embeddings"
+                assert results_dir.exists()
+
+                # Get the results file (should be only one .json file)
+                results_files = list(results_dir.glob("*.json"))
+                assert len(results_files) == 1
+
+                results_file = results_files[0]
+
+                # Validate results file contents
+                file_content = json.loads(results_file.read_text())
+                assert len(file_content) == 3
+
+                # Validate that all document IDs are present in results
+                result_document_ids = {result["document_id"] for result in file_content}
+                assert result_document_ids == set(document_import_ids)
+
+                # Validate that results have the expected structure
+                for result in file_content:
+                    assert "document_id" in result
+                    assert "error" in result
 
 
 def test_s3_client(
@@ -160,3 +190,187 @@ def test_run_encoder_s3(
         file_text = file_obj["Body"]
         file_bytes = io.BytesIO(file_text.read())
         assert np.load(file_bytes).shape[1] == 768
+
+    # Validate that results file is produced in S3
+    results_prefix = "input/2023-04-13T09.17.37.953810/reports/embeddings/"
+    results_list_response = pipeline_s3_client_main.client.list_objects_v2(
+        Bucket=s3_bucket_and_region["bucket"], Prefix=results_prefix
+    )
+
+    # Should have one results file
+    assert results_list_response["KeyCount"] == 1
+
+    # Get the results file key
+    results_key = results_list_response["Contents"][0]["Key"]
+
+    # Read and validate the results file
+    results_path = f"s3://{s3_bucket_and_region['bucket']}/{results_key}"
+    file_content = json.loads(s3_object_read_text(results_path))
+
+    assert len(file_content) == len(document_import_ids)
+
+    # Validate that all document IDs are present in results
+    result_document_ids = {result["document_id"] for result in file_content}
+    assert result_document_ids == set(document_import_ids)
+
+    # Validate that results have the expected structure
+    for result in file_content:
+        assert "document_id" in result
+        assert "error" in result
+
+
+def test_process_document_success(test_pdf_file_json) -> None:
+    """Test that process_document successfully processes a document and collects results."""
+    document_id = "test_doc_123"
+
+    with tempfile.TemporaryDirectory() as input_dir:
+        with tempfile.TemporaryDirectory() as output_dir:
+            # Create input JSON file
+            input_file = Path(input_dir) / f"{document_id}.json"
+            input_file.write_text(json.dumps(test_pdf_file_json))
+
+            # Mock encoder
+            mock_encoder = MagicMock()
+            mock_encoder.encode.return_value = np.array([0.1] * 768)
+            mock_encoder.encode_batch.return_value = np.array(
+                [[0.2] * 768, [0.3] * 768]
+            )
+
+            # Process document
+            result = process_document(
+                document_id=document_id,
+                encoder=mock_encoder,
+                input_dir=input_dir,
+                output_dir=output_dir,
+                s3=False,
+                device="cpu",
+            )
+
+            # Validate result collection
+            assert isinstance(result, EmbeddingResult)
+            assert result.document_id == document_id
+            assert result.error is None
+
+            # Validate output files were created
+            output_json = Path(output_dir) / f"{test_pdf_file_json['document_id']}.json"
+            output_npy = Path(output_dir) / f"{test_pdf_file_json['document_id']}.npy"
+
+            assert output_json.exists()
+            assert output_npy.exists()
+
+            # Validate JSON output
+            output_data = json.loads(output_json.read_text())
+            assert ParserOutput.model_validate(output_data)
+
+            # Validate embeddings output
+            embeddings = np.load(str(output_npy))
+            assert embeddings.shape[1] == 768
+
+
+def test_process_document_error_handling() -> None:
+    """Test that process_document catches errors and returns them in the result."""
+    document_id = "test_doc_456"
+
+    with tempfile.TemporaryDirectory() as input_dir:
+        with tempfile.TemporaryDirectory() as output_dir:
+            # Create input JSON file with invalid content to trigger an error
+            input_file = Path(input_dir) / f"{document_id}.json"
+            input_file.write_text("invalid json content")
+
+            # Mock encoder
+            mock_encoder = MagicMock()
+
+            # Process document - should catch the JSON parsing error
+            result = process_document(
+                document_id=document_id,
+                encoder=mock_encoder,
+                input_dir=input_dir,
+                output_dir=output_dir,
+                s3=False,
+                device="cpu",
+            )
+
+            # Validate error was caught and returned
+            assert isinstance(result, EmbeddingResult)
+            assert result.document_id == document_id
+            assert result.error is not None
+            assert (
+                "ValidationError" in result.error
+                or "JSONDecodeError" in result.error
+                or "ValueError" in result.error
+            )
+
+
+def test_write_results_file_local() -> None:
+    """Test that write_results_file writes results to local filesystem correctly."""
+    results = [
+        EmbeddingResult(document_id="doc1", error=None),
+        EmbeddingResult(document_id="doc2", error="SomeError: error message"),
+        EmbeddingResult(document_id="doc3", error=None),
+    ]
+
+    with tempfile.TemporaryDirectory() as input_dir:
+        # Write results to local filesystem
+        write_results_file(results=results, input_dir_path=input_dir, s3=False)
+
+        # Find the results file (it has a random UUID filename)
+        results_dir = Path(input_dir) / "reports" / "embeddings"
+        assert results_dir.exists()
+
+        # Get the results file (should be only one .json file)
+        results_files = list(results_dir.glob("*.json"))
+        assert len(results_files) == 1
+
+        results_file = results_files[0]
+
+        # Validate file contents
+        file_content = json.loads(results_file.read_text())
+        assert len(file_content) == 3
+
+        # Validate each result
+        assert file_content[0]["document_id"] == "doc1"
+        assert file_content[0]["error"] is None
+
+        assert file_content[1]["document_id"] == "doc2"
+        assert file_content[1]["error"] == "SomeError: error message"
+
+        assert file_content[2]["document_id"] == "doc3"
+        assert file_content[2]["error"] is None
+
+
+def test_write_results_file_s3(s3_bucket_and_region, pipeline_s3_client_main) -> None:
+    """Test that write_results_file writes results to S3 correctly."""
+    results = [
+        EmbeddingResult(document_id="doc1", error=None),
+        EmbeddingResult(document_id="doc2", error="SomeError: error message"),
+    ]
+
+    input_dir_path = f's3://{s3_bucket_and_region["bucket"]}/input/test_run/'
+
+    # Write results to S3
+    write_results_file(results=results, input_dir_path=input_dir_path, s3=True)
+
+    # List objects in the results directory
+    list_response = pipeline_s3_client_main.client.list_objects_v2(
+        Bucket=s3_bucket_and_region["bucket"],
+        Prefix="input/test_run/reports/embeddings/",
+    )
+
+    # Should have one results file
+    assert list_response["KeyCount"] == 1
+
+    # Get the results file key
+    results_key = list_response["Contents"][0]["Key"]
+
+    # Read and validate the results file
+    results_path = f"s3://{s3_bucket_and_region['bucket']}/{results_key}"
+    file_content = json.loads(s3_object_read_text(results_path))
+
+    assert len(file_content) == 2
+
+    # Validate each result
+    assert file_content[0]["document_id"] == "doc1"
+    assert file_content[0]["error"] is None
+
+    assert file_content[1]["document_id"] == "doc2"
+    assert file_content[1]["error"] == "SomeError: error message"

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -187,64 +187,56 @@ def test_parser_output_array() -> List[ParserOutput]:
 
 
 @pytest.fixture
-def test_parser_output_no_source_url_no_lang_no_data() -> List[ParserOutput]:
-    return [
-        get_parser_output(
-            html_data=None,
-            source_url=None,
-            languages=None,
-            content_type=None,
-            translated=False,
-        )
-    ]
+def test_parser_output_no_source_url_no_lang_no_data() -> ParserOutput:
+    return get_parser_output(
+        html_data=None,
+        source_url=None,
+        languages=None,
+        content_type=None,
+        translated=False,
+    )
 
 
 @pytest.fixture
-def test_parser_output_source_url_no_lang_no_data() -> List[ParserOutput]:
-    return [
-        get_parser_output(
-            html_data=None,
-            source_url="https://www.example.com/files/climate-document.pdf",
-            languages=None,
-            content_type=None,
-            translated=False,
-        )
-    ]
+def test_parser_output_source_url_no_lang_no_data() -> ParserOutput:
+    return get_parser_output(
+        html_data=None,
+        source_url="https://www.example.com/files/climate-document.pdf",
+        languages=None,
+        content_type=None,
+        translated=False,
+    )
 
 
 @pytest.fixture
-def test_parser_output_source_url_supported_lang_data() -> List[ParserOutput]:
-    return [
-        get_parser_output(
-            html_data=HTMLData(
-                has_valid_text=True,
-                text_blocks=[
-                    get_html_text_block("Table"),
-                    get_html_text_block("Google Text Block"),
-                ],
-            ),
-            source_url="https://www.example.com/files/climate-document.pdf",
-            languages=["en"],
-            content_type="text/html",
-            translated=False,
-        )
-    ]
+def test_parser_output_source_url_supported_lang_data() -> ParserOutput:
+    return get_parser_output(
+        html_data=HTMLData(
+            has_valid_text=True,
+            text_blocks=[
+                get_html_text_block("Table"),
+                get_html_text_block("Google Text Block"),
+            ],
+        ),
+        source_url="https://www.example.com/files/climate-document.pdf",
+        languages=["en"],
+        content_type="text/html",
+        translated=False,
+    )
 
 
 @pytest.fixture
-def test_parser_output_source_url_un_supported_lang_data() -> List[ParserOutput]:
-    return [
-        get_parser_output(
-            html_data=HTMLData(
-                has_valid_text=True,
-                text_blocks=[
-                    get_html_text_block("Table"),
-                    get_html_text_block("Google Text Block"),
-                ],
-            ),
-            source_url="https://www.example.com/files/climate-document.pdf",
-            languages=["fr"],
-            content_type="text/html",
-            translated=False,
-        )
-    ]
+def test_parser_output_source_url_un_supported_lang_data() -> ParserOutput:
+    return get_parser_output(
+        html_data=HTMLData(
+            has_valid_text=True,
+            text_blocks=[
+                get_html_text_block("Table"),
+                get_html_text_block("Google Text Block"),
+            ],
+        ),
+        source_url="https://www.example.com/files/climate-document.pdf",
+        languages=["fr"],
+        content_type="text/html",
+        translated=False,
+    )

--- a/tests/src/test_languages.py
+++ b/tests/src/test_languages.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from cpr_sdk.parser_models import ParserOutput
 
 from src.languages import doc_has_supported_language
@@ -9,10 +7,10 @@ from src.languages import doc_has_supported_language
 
 
 def test_doc_has_supported_language(
-    test_parser_output_no_source_url_no_lang_no_data: List[ParserOutput],
-    test_parser_output_source_url_no_lang_no_data: List[ParserOutput],
-    test_parser_output_source_url_supported_lang_data: List[ParserOutput],
-    test_parser_output_source_url_un_supported_lang_data: List[ParserOutput],
+    test_parser_output_no_source_url_no_lang_no_data: ParserOutput,
+    test_parser_output_source_url_no_lang_no_data: ParserOutput,
+    test_parser_output_source_url_supported_lang_data: ParserOutput,
+    test_parser_output_source_url_un_supported_lang_data: ParserOutput,
 ):
     """Tests that the function returns only docs of a supported language."""
     assert (

--- a/tests/src/test_languages.py
+++ b/tests/src/test_languages.py
@@ -2,13 +2,13 @@ from typing import List
 
 from cpr_sdk.parser_models import ParserOutput
 
-from src.languages import get_docs_of_supported_language
+from src.languages import doc_has_supported_language
 
 # TODO test that the warning is logged if the document language is not supported by
 #  the encoder
 
 
-def test_get_docs_of_supported_language(
+def test_doc_has_supported_language(
     test_parser_output_no_source_url_no_lang_no_data: List[ParserOutput],
     test_parser_output_source_url_no_lang_no_data: List[ParserOutput],
     test_parser_output_source_url_supported_lang_data: List[ParserOutput],
@@ -16,25 +16,21 @@ def test_get_docs_of_supported_language(
 ):
     """Tests that the function returns only docs of a supported language."""
     assert (
-        get_docs_of_supported_language(test_parser_output_no_source_url_no_lang_no_data)
-        == test_parser_output_no_source_url_no_lang_no_data
+        doc_has_supported_language(test_parser_output_no_source_url_no_lang_no_data)
+        is True
     )
 
     assert (
-        get_docs_of_supported_language(test_parser_output_source_url_no_lang_no_data)
-        == []
+        doc_has_supported_language(test_parser_output_source_url_no_lang_no_data)
+        is False
     )
 
     assert (
-        get_docs_of_supported_language(
-            test_parser_output_source_url_supported_lang_data
-        )
-        == test_parser_output_source_url_supported_lang_data
+        doc_has_supported_language(test_parser_output_source_url_supported_lang_data)
+        is True
     )
 
     assert (
-        get_docs_of_supported_language(
-            test_parser_output_source_url_un_supported_lang_data
-        )
-        == []
+        doc_has_supported_language(test_parser_output_source_url_un_supported_lang_data)
+        is False
     )

--- a/tests/src/test_s3.py
+++ b/tests/src/test_s3.py
@@ -3,10 +3,10 @@ import json
 import numpy as np
 
 from src.s3 import (
-    validate_s3_pattern,
     s3_object_read_text,
-    write_json_to_s3,
     save_ndarray_to_s3_as_npy,
+    validate_s3_pattern,
+    write_json_to_s3,
 )
 
 
@@ -51,7 +51,7 @@ def test_save_ndarray_to_s3_as_npy(pipeline_s3_client, s3_bucket_and_region):
         np.array([1, 2, 3]), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy"
     )
 
-    response = pipeline_s3_client.list_objects_v2(
+    response = pipeline_s3_client.client.list_objects_v2(
         Bucket=s3_bucket_and_region["bucket"], Prefix="prefix/test.npy"
     )
     contents = response.get("Contents", [])

--- a/tests/src/test_s3.py
+++ b/tests/src/test_s3.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from src.s3 import (
     validate_s3_pattern,
-    check_file_exists_in_s3,
     s3_object_read_text,
     write_json_to_s3,
     save_ndarray_to_s3_as_npy,
@@ -23,13 +22,6 @@ def test_validate_s3_pattern(test_file_key):
         validate_s3_pattern("random_string")
     except Exception as e:
         assert "Key does not represent an s3 path: random_string" in str(e)
-
-
-def test_check_file_exists_in_s3(pipeline_s3_client, test_file_key):
-    """Test whether we can check whether a file exists in s3."""
-
-    assert check_file_exists_in_s3(f"s3://{test_file_key}")
-    assert not check_file_exists_in_s3("s3://random_bucket/prefix/file.json")
 
 
 def test_s3_object_read_text(pipeline_s3_client, test_file_key, test_file_json):
@@ -59,9 +51,11 @@ def test_save_ndarray_to_s3_as_npy(pipeline_s3_client, s3_bucket_and_region):
         np.array([1, 2, 3]), f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy"
     )
 
-    assert check_file_exists_in_s3(
-        f"s3://{s3_bucket_and_region['bucket']}/prefix/test.npy"
+    response = pipeline_s3_client.list_objects_v2(
+        Bucket=s3_bucket_and_region["bucket"], Prefix="prefix/test.npy"
     )
+    contents = response.get("Contents", [])
+    assert any(obj["Key"] == "prefix/test.npy" for obj in contents)
 
     try:
         save_ndarray_to_s3_as_npy(

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -131,7 +131,3 @@ def test_encode_indexer_input(test_pdf_file_json):  # noqa: F811
 
     assert isinstance(description_embeddings, np.ndarray)
     assert isinstance(text_embeddings, np.ndarray)
-
-
-# TODO get_Text2EmbeddingsInput_array
-#   TODO needs s3 files, local files, of the form json IndexerInput objects

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -17,28 +17,31 @@ from src.utils import (
 def test_filter_on_block_type(test_parser_output_array):
     """Tests that the filter_on_block_type function removes the correct text blocks."""
 
-    filtered_inputs = filter_on_block_type(
-        inputs=test_parser_output_array, remove_block_types=["Text", "Figure"]
+    parser_output = filter_on_block_type(
+        document=test_parser_output_array[0], remove_block_types=["Text", "Figure"]
     )
 
-    assert filtered_inputs[0].html_data is not None
-    assert len(filtered_inputs[0].html_data.text_blocks) == 2
+    assert parser_output.html_data is not None
+    assert len(parser_output.html_data.text_blocks) == 2
 
-    assert filtered_inputs[0].html_data.text_blocks[0].type == "Table"
-    assert filtered_inputs[0].html_data.text_blocks[0].text == ["test_text"]
+    assert parser_output.html_data.text_blocks[0].type == "Table"
+    assert parser_output.html_data.text_blocks[0].text == ["test_text"]
 
-    assert filtered_inputs[0].html_data.text_blocks[1].type == "Google Text Block"
-    assert filtered_inputs[0].html_data.text_blocks[1].text == ["test_text"]
+    assert parser_output.html_data.text_blocks[1].type == "Google Text Block"
+    assert parser_output.html_data.text_blocks[1].text == ["test_text"]
 
     # Assert that we can filter on IndexerInputs that don't have valid text
-    assert filtered_inputs[1].html_data is not None
-    assert len(filtered_inputs[1].html_data.text_blocks) == 2
+    parser_output = filter_on_block_type(
+        document=test_parser_output_array[1], remove_block_types=["Text", "Figure"]
+    )
+    assert parser_output.html_data is not None
+    assert len(parser_output.html_data.text_blocks) == 2
 
-    assert filtered_inputs[1].html_data.text_blocks[0].type == "Table"
-    assert filtered_inputs[1].html_data.text_blocks[0].text == ["test_text"]
+    assert parser_output.html_data.text_blocks[0].type == "Table"
+    assert parser_output.html_data.text_blocks[0].text == ["test_text"]
 
-    assert filtered_inputs[1].html_data.text_blocks[1].type == "Google Text Block"
-    assert filtered_inputs[1].html_data.text_blocks[1].text == ["test_text"]
+    assert parser_output.html_data.text_blocks[1].type == "Google Text Block"
+    assert parser_output.html_data.text_blocks[1].text == ["test_text"]
 
 
 def test_has_valid_text_override(test_parser_output_array: Sequence[ParserOutput]):


### PR DESCRIPTION
This Pull Request: 
---
- Collects errors during embeddings generation and writes them out to a results file.
- This job runs concurrently so saving the results from each batch with a unique file name within a `reports/embeddings` sub directory. 
- Required the addition of the `input_dir_path` param so we know where to persist the error results to. This then caused some naming changes to the `input_dir` and `output_dir` params as they are too similar. I wanted to keep `input_dir_path` so we're consistent across all of the jobs although its not a super clear name. 
- Refactors the `text2embeddings` module to enable easier results collection. 