### PR TITLE
Bugfix: Embeddings Find Translated Files From Document Ids

### DIFF
--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -53,6 +53,48 @@ class EmbeddingResult(BaseModel):
     error: Optional[str] = None
 
 
+def load_document_json(
+    document_id: DocumentImportId, input_dir: str, s3: bool, target_lang: str
+) -> str:
+    """
+    Load document JSON content, trying translated version first.
+
+    Tries to find a translated version of the document with the suffix
+    translated_{target_language}.json. If it doesn't exist, falls back to
+    the default path {document_id}.json.
+
+    Args:
+        document_id: The document import ID to load
+        input_dir: Directory containing input JSON files
+        s3: Whether to use S3 for I/O
+        target_lang: Target language code to look for in translated filename
+
+    Returns:
+        JSON content as a string
+
+    Raises:
+        ValueError: If the file doesn't exist (for S3)
+        FileNotFoundError: If the file doesn't exist (for local filesystem)
+    """
+    # Try to find a translated version first
+    translated_path = os.path.join(
+        input_dir, f"{document_id}_translated_{target_lang}.json"
+    )
+    if s3:
+        try:
+            return s3_object_read_text(translated_path)
+        except ValueError:
+            # File doesn't exist, fall through to default path
+            pass
+    else:
+        if Path(translated_path).exists():
+            return Path(translated_path).read_text()
+
+    # If no translated version found, use the default path
+    file_path = os.path.join(input_dir, document_id + ".json")
+    return s3_object_read_text(file_path) if s3 else Path(file_path).read_text()
+
+
 def process_document(
     document_id: DocumentImportId,
     encoder: SBERTEncoder,
@@ -86,10 +128,9 @@ def process_document(
 
     try:
         # Step 1: Load document
-        file_path = os.path.join(input_dir, document_id + ".json")
-        json_content = (
-            s3_object_read_text(file_path) if s3 else Path(file_path).read_text()
-        )
+        assert len(config.TARGET_LANGUAGES) == 1, "Must be one target language."
+        target_lang = next(iter(config.TARGET_LANGUAGES))
+        json_content = load_document_json(document_id, input_dir, s3, target_lang)
         parser_output = ParserOutput.model_validate_json(json_content)
 
         # Step 2: Check if language is supported

--- a/tests/cli/test_text2embeddings.py
+++ b/tests/cli/test_text2embeddings.py
@@ -101,6 +101,81 @@ def test_run_encoder_local(
                     assert "error" in result
 
 
+def test_run_embeddings_on_translated(
+    test_html_file_json,
+    test_pdf_file_json,
+    test_no_content_type_file_json,
+):
+    """Test that the embeddings generation cli can handle translated documents."""
+
+    with tempfile.TemporaryDirectory() as embeddings_input_dir_path:
+        with tempfile.TemporaryDirectory() as embeddings_output_dir_path:
+            with tempfile.TemporaryDirectory() as input_dir_path:
+                # Create HTML File
+                html_file_path = (
+                    Path(embeddings_input_dir_path)
+                    / f"{test_html_file_json['document_id']}.json"
+                )
+                html_file_path.write_text(json.dumps(test_html_file_json))
+
+                # Create PDF File
+                pdf_file_path = (
+                    Path(embeddings_input_dir_path)
+                    / f"{test_pdf_file_json['document_id']}.json"
+                )
+                pdf_file_path.write_text(json.dumps(test_pdf_file_json))
+
+                # Create No Content Type File (both non/translated)
+                test_no_content_type_file_json["translated"] = True
+                no_content_type_translated_file_path = (
+                    Path(embeddings_input_dir_path)
+                    / f"{test_no_content_type_file_json['document_id']}_translated_en.json"
+                )
+                no_content_type_translated_file_path.write_text(
+                    json.dumps(test_no_content_type_file_json)
+                )
+
+                test_no_content_type_file_json["translated"] = False
+                test_no_content_type_file_json["languages"] = ["fr"]
+
+                no_content_type_file_path = (
+                    Path(embeddings_input_dir_path)
+                    / f"{test_no_content_type_file_json['document_id']}.json"
+                )
+                no_content_type_file_path.write_text(
+                    json.dumps(test_no_content_type_file_json)
+                )
+
+                document_import_ids = [
+                    test_html_file_json["document_id"],
+                    test_pdf_file_json["document_id"],
+                    test_no_content_type_file_json["document_id"],
+                ]
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    run_as_cli,
+                    [
+                        input_dir_path,
+                        embeddings_input_dir_path,
+                        embeddings_output_dir_path,
+                        ",".join(document_import_ids),
+                    ],
+                )
+                assert result.exit_code == 0
+
+                assert set(Path(embeddings_output_dir_path).glob("*.json")) == {
+                    Path(embeddings_output_dir_path) / "test_html.json",
+                    Path(embeddings_output_dir_path) / "test_pdf.json",
+                    Path(embeddings_output_dir_path) / "test_no_content_type.json",
+                }
+                assert set(Path(embeddings_output_dir_path).glob("*.npy")) == {
+                    Path(embeddings_output_dir_path) / "test_html.npy",
+                    Path(embeddings_output_dir_path) / "test_pdf.npy",
+                    Path(embeddings_output_dir_path) / "test_no_content_type.npy",
+                }
+
+
 def test_s3_client(
     s3_bucket_and_region,
     pipeline_s3_objects_main,


### PR DESCRIPTION
This Pull Request: 
----
- Is a bug fix for an error identified in the pipeline integration tests. 
- Essentially we're pasing document ids into the embeddings job, but it may need to read from translated files. 
- E.g. `CCLW.exec.1.1_translated_en.json` not `CCLW.exec.1.1.json`. 
- Therefore, this PR added a failing test and then handling for finding translated docs. The solution is to search for translated versions of a file first, if this doesn't exist then fall back to the default path. 
- I've had to put in an assertion that `TARGET_LANGUAGES` is a set of 1. This is as if we had two for example which one would we pick to send downstream? Currently the indexer input prefix utilises document id as the file stem, all with language english. 
- I also thought about handling the logic of files to run on at the top level document processing flow but I think it's better just to pass in document ids still and let the job handle the translated logic as it's currently specific to the embeddings job. 